### PR TITLE
Update region query, add queries for other geographies

### DIFF
--- a/statistics/queries/continent_country_histogram.sql
+++ b/statistics/queries/continent_country_histogram.sql
@@ -1,0 +1,291 @@
+WITH
+# Select the initial set of results
+dl_per_location AS (
+  SELECT
+    date,
+    client.Geo.continent_code AS continent_code,
+    client.Geo.country_code AS country_code,
+    client.Geo.country_name AS country_name,
+    a.MeanThroughputMbps AS mbps,
+    NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
+  FROM `measurement-lab.ndt.unified_downloads`
+  WHERE date BETWEEN @startdate AND @enddate
+  AND a.MeanThroughputMbps != 0
+),
+# With good locations and valid IPs
+dl_per_location_cleaned AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    mbps,
+    ip
+  FROM dl_per_location
+  WHERE
+    continent_code IS NOT NULL AND continent_code != ""
+    AND country_code IS NOT NULL AND country_code != ""
+    AND country_name IS NOT NULL AND country_name != ""
+    AND ip IS NOT NULL
+),
+# Gather descriptive statistics per geo, day, per ip
+dl_stats_perip_perday AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    ip,
+    MIN(mbps) AS MIN_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
+    AVG(mbps) AS MEAN_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
+    MAX(mbps) AS MAX_download_Mbps
+  FROM dl_per_location_cleaned
+  GROUP BY date, continent_code, country_code, country_name, ip
+),
+# Calculate final stats per day from 1x test per ip per day normalization in prev. step
+dl_stats_per_day AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    MIN(MIN_download_Mbps) AS MIN_download_Mbps,
+    APPROX_QUANTILES(LOWER_QUART_download_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
+    APPROX_QUANTILES(MED_download_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
+    AVG(MEAN_download_Mbps) AS MEAN_download_Mbps,
+    APPROX_QUANTILES(UPPER_QUART_download_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
+    MAX(MAX_download_Mbps) AS MAX_download_Mbps
+  FROM
+    dl_stats_perip_perday
+  GROUP BY date, continent_code, country_code, country_name
+),
+dl_total_samples_per_geo AS (
+  SELECT
+    date,
+    COUNT(*) AS dl_total_samples,
+    continent_code,
+    country_code,
+    country_name
+  FROM dl_per_location_cleaned
+  GROUP BY date, continent_code, country_code, country_name
+),
+# Now generate daily histograms of Max DL
+max_dl_per_day_ip AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    ip,
+    MAX(mbps) AS mbps
+  FROM dl_per_location_cleaned
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    ip
+),
+# Count the samples
+dl_sample_counts AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    COUNT(*) AS samples
+  FROM max_dl_per_day_ip
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
+    country_name
+),
+# Generate equal sized buckets in log-space
+buckets AS (
+  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
+  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+),
+# Count the samples that fall into each bucket
+dl_histogram_counts AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
+  FROM max_dl_per_day_ip CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    bucket_min,
+    bucket_max
+),
+# Turn the counts into frequencies
+dl_histogram AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    bucket_min,
+    bucket_max,
+    bucket_count / samples AS dl_frac,
+    samples AS dl_samples
+  FROM dl_histogram_counts
+  JOIN dl_sample_counts USING (date, continent_code, country_code, country_name)
+),
+# Repeat for Upload tests
+# Select the initial set of upload results
+ul_per_location AS (
+  SELECT
+    date,
+    client.Geo.continent_code AS continent_code,
+    client.Geo.country_code AS country_code,
+    client.Geo.country_name AS country_name,
+    a.MeanThroughputMbps AS mbps,
+    NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
+  FROM `measurement-lab.ndt.unified_uploads`
+  WHERE date BETWEEN @startdate AND @enddate
+  AND a.MeanThroughputMbps != 0
+),
+# With good locations and valid IPs
+ul_per_location_cleaned AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    mbps,
+    ip
+  FROM ul_per_location
+  WHERE
+    continent_code IS NOT NULL AND continent_code != ""
+    AND country_code IS NOT NULL AND country_code != ""
+    AND country_name IS NOT NULL AND country_name != ""
+    AND ip IS NOT NULL
+),
+# Gather descriptive statistics per geo, day, per ip
+ul_stats_perip_perday AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    ip,
+    MIN(mbps) AS MIN_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_upload_Mbps,
+    AVG(mbps) AS MEAN_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_upload_Mbps,
+    MAX(mbps) AS MAX_upload_Mbps
+  FROM ul_per_location_cleaned
+  GROUP BY date, continent_code, country_code, country_name, ip
+),
+# Calculate final stats per day from 1x test per ip per day normalization in prev. step
+ul_stats_per_day AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    MIN(MIN_upload_Mbps) AS MIN_upload_Mbps,
+    APPROX_QUANTILES(LOWER_QUART_upload_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_upload_Mbps,
+    APPROX_QUANTILES(MED_upload_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_upload_Mbps,
+    AVG(MEAN_upload_Mbps) AS MEAN_upload_Mbps,
+    APPROX_QUANTILES(UPPER_QUART_upload_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_upload_Mbps,
+    MAX(MAX_upload_Mbps) AS MAX_upload_Mbps
+  FROM
+    ul_stats_perip_perday
+  GROUP BY date, continent_code, country_code, country_name
+),
+ul_total_samples_per_geo AS (
+  SELECT
+    date,
+    COUNT(*) AS ul_total_samples,
+    continent_code,
+    country_code,
+    country_name
+  FROM ul_per_location_cleaned
+  GROUP BY date, continent_code, country_code, country_name
+),
+# Now generate daily histograms of Max UL
+max_ul_per_day_ip AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    ip,
+    MAX(mbps) AS mbps
+  FROM ul_per_location_cleaned
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    ip
+),
+# Count the samples
+ul_sample_counts AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    COUNT(*) AS samples
+  FROM max_ul_per_day_ip
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
+    country_name
+),
+# Count the samples that fall into each bucket
+ul_histogram_counts AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
+  FROM max_ul_per_day_ip CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    bucket_min,
+    bucket_max
+),
+# Turn the counts into frequencies
+ul_histogram AS (
+  SELECT
+    date,
+    continent_code,
+    country_code,
+    country_name,
+    bucket_min,
+    bucket_max,
+    bucket_count / samples AS ul_frac,
+    samples AS ul_samples
+  FROM ul_histogram_counts
+  JOIN ul_sample_counts USING (date, continent_code, country_code, country_name)
+)
+# Show the results
+SELECT * FROM dl_histogram
+JOIN ul_histogram USING (date, continent_code, country_code, country_name, bucket_min, bucket_max)
+JOIN dl_stats_per_day USING (date, continent_code, country_code, country_name)
+JOIN dl_total_samples_per_geo USING (date, continent_code, country_code, country_name)
+JOIN ul_stats_per_day USING (date, continent_code, country_code, country_name)
+JOIN ul_total_samples_per_geo USING (date, continent_code, country_code, country_name)
+ORDER BY date, continent_code, country_code, country_name, bucket_min, bucket_max

--- a/statistics/queries/continent_country_region_city_histogram.sql
+++ b/statistics/queries/continent_country_region_city_histogram.sql
@@ -44,12 +44,12 @@ dl_stats_perip_perday AS (
     ISO3166_2region1,
     city,
     ip,
-    MIN(mbps) AS MIN_download_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
-    AVG(mbps) AS MEAN_download_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
-    MAX(mbps) AS MAX_download_Mbps
+    MIN(mbps) AS download_MIN,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS download_Q25,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS download_MED,
+    AVG(mbps) AS download_AVG,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS download_Q75,
+    MAX(mbps) AS download_MAX
   FROM dl_per_location_cleaned
   GROUP BY date, continent_code, country_code, country_name, ISO3166_2region1, city, ip
 ),
@@ -62,12 +62,12 @@ dl_stats_per_day AS (
     country_name,
     ISO3166_2region1,
     city,
-    MIN(MIN_download_Mbps) AS MIN_download_Mbps,
-    APPROX_QUANTILES(LOWER_QUART_download_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
-    APPROX_QUANTILES(MED_download_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
-    AVG(MEAN_download_Mbps) AS MEAN_download_Mbps,
-    APPROX_QUANTILES(UPPER_QUART_download_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
-    MAX(MAX_download_Mbps) AS MAX_download_Mbps
+    MIN(download_MIN) AS download_MIN,
+    APPROX_QUANTILES(download_Q25, 100) [SAFE_ORDINAL(25)] AS download_Q25,
+    APPROX_QUANTILES(download_MED, 100) [SAFE_ORDINAL(50)] AS download_MED,
+    AVG(download_AVG) AS download_AVG,
+    APPROX_QUANTILES(download_Q75, 100) [SAFE_ORDINAL(75)] AS download_Q75,
+    MAX(download_MAX) AS download_MAX
   FROM
     dl_stats_perip_perday
   GROUP BY date, continent_code, country_code, country_name, ISO3166_2region1, city
@@ -343,4 +343,3 @@ JOIN dl_stats_per_day USING (date, continent_code, country_code, country_name, I
 JOIN dl_total_samples_per_geo USING (date, continent_code, country_code, country_name, ISO3166_2region1, city)
 JOIN ul_stats_per_day USING (date, continent_code, country_code, country_name, ISO3166_2region1, city)
 JOIN ul_total_samples_per_geo USING (date, continent_code, country_code, country_name, ISO3166_2region1, city)
-ORDER BY date, continent_code, country_code, country_name, ISO3166_2region1, city, bucket_min, bucket_max

--- a/statistics/queries/continent_country_region_histogram.sql
+++ b/statistics/queries/continent_country_region_histogram.sql
@@ -364,4 +364,3 @@ JOIN dl_stats_perday USING (date, continent_code, country_code, country_name, IS
 JOIN dl_total_samples_pergeo_perday USING (date, continent_code, country_code, country_name, ISO3166_2region1)
 JOIN ul_stats_perday USING (date, continent_code, country_code, country_name, ISO3166_2region1)
 JOIN ul_total_samples_pergeo_perday USING (date, continent_code, country_code, country_name, ISO3166_2region1)
-ORDER BY date, continent_code, country_code, country_name, ISO3166_2region1, bucket_min, bucket_max

--- a/statistics/queries/continent_histogram.sql
+++ b/statistics/queries/continent_histogram.sql
@@ -28,12 +28,12 @@ dl_stats_perip_perday AS (
     date,
     continent_code,
     ip,
-    MIN(mbps) AS MIN_download_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
-    AVG(mbps) AS MEAN_download_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
-    MAX(mbps) AS MAX_download_Mbps
+    MIN(mbps) AS download_MIN,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS download_Q25,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS download_MED,
+    AVG(mbps) AS download_AVG,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS download_Q75,
+    MAX(mbps) AS download_MAX
   FROM dl_per_location_cleaned
   GROUP BY date, continent_code, ip
 ),
@@ -42,12 +42,12 @@ dl_stats_per_day AS (
   SELECT
     date,
     continent_code,
-    MIN(MIN_download_Mbps) AS MIN_download_Mbps,
-    APPROX_QUANTILES(LOWER_QUART_download_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
-    APPROX_QUANTILES(MED_download_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
-    AVG(MEAN_download_Mbps) AS MEAN_download_Mbps,
-    APPROX_QUANTILES(UPPER_QUART_download_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
-    MAX(MAX_download_Mbps) AS MAX_download_Mbps
+    MIN(download_MIN) AS download_MIN,
+    APPROX_QUANTILES(download_Q25, 100) [SAFE_ORDINAL(25)] AS download_Q25,
+    APPROX_QUANTILES(download_MED, 100) [SAFE_ORDINAL(50)] AS download_MED,
+    AVG(download_AVG) AS download_AVG,
+    APPROX_QUANTILES(download_Q75, 100) [SAFE_ORDINAL(75)] AS download_Q75,
+    MAX(download_MAX) AS download_MAX
   FROM
     dl_stats_perip_perday
   GROUP BY date, continent_code
@@ -146,12 +146,12 @@ ul_stats_perip_perday AS (
     date,
     continent_code,
     ip,
-    MIN(mbps) AS MIN_upload_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_upload_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_upload_Mbps,
-    AVG(mbps) AS MEAN_upload_Mbps,
-    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_upload_Mbps,
-    MAX(mbps) AS MAX_upload_Mbps
+    MIN(mbps) AS upload_MIN,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS upload_Q25,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS upload_MED,
+    AVG(mbps) AS upload_AVG,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS upload_Q75,
+    MAX(mbps) AS upload_MAX
   FROM ul_per_location_cleaned
   GROUP BY date, continent_code, ip
 ),
@@ -160,12 +160,12 @@ ul_stats_per_day AS (
   SELECT
     date,
     continent_code,
-    MIN(MIN_upload_Mbps) AS MIN_upload_Mbps,
-    APPROX_QUANTILES(LOWER_QUART_upload_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_upload_Mbps,
-    APPROX_QUANTILES(MED_upload_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_upload_Mbps,
-    AVG(MEAN_upload_Mbps) AS MEAN_upload_Mbps,
-    APPROX_QUANTILES(UPPER_QUART_upload_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_upload_Mbps,
-    MAX(MAX_upload_Mbps) AS MAX_upload_Mbps
+    MIN(upload_MIN) AS upload_MIN,
+    APPROX_QUANTILES(upload_Q25, 100) [SAFE_ORDINAL(25)] AS upload_Q25,
+    APPROX_QUANTILES(upload_MED, 100) [SAFE_ORDINAL(50)] AS upload_MED,
+    AVG(upload_AVG) AS upload_AVG,
+    APPROX_QUANTILES(upload_Q75, 100) [SAFE_ORDINAL(75)] AS upload_Q75,
+    MAX(upload_MAX) AS upload_MAX
   FROM
     ul_stats_perip_perday
   GROUP BY date, continent_code
@@ -236,4 +236,3 @@ JOIN dl_stats_per_day USING (date, continent_code)
 JOIN dl_total_samples_per_geo USING (date, continent_code)
 JOIN ul_stats_per_day USING (date, continent_code)
 JOIN ul_total_samples_per_geo USING (date, continent_code)
-ORDER BY date, continent_code, bucket_min, bucket_max

--- a/statistics/queries/continent_histogram.sql
+++ b/statistics/queries/continent_histogram.sql
@@ -1,0 +1,239 @@
+WITH
+# Select the initial set of results
+dl_per_location AS (
+  SELECT
+    date,
+    client.Geo.continent_code AS continent_code,
+    a.MeanThroughputMbps AS mbps,
+    NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
+  FROM `measurement-lab.ndt.unified_downloads`
+  WHERE date BETWEEN @startdate AND @enddate
+  AND a.MeanThroughputMbps != 0
+),
+# With good locations and valid IPs
+dl_per_location_cleaned AS (
+  SELECT
+    date,
+    continent_code,
+    mbps,
+    ip
+  FROM dl_per_location
+  WHERE
+    continent_code IS NOT NULL AND continent_code != ""
+    AND ip IS NOT NULL
+),
+# Gather descriptive statistics per geo, day, per ip
+dl_stats_perip_perday AS (
+  SELECT
+    date,
+    continent_code,
+    ip,
+    MIN(mbps) AS MIN_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
+    AVG(mbps) AS MEAN_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
+    MAX(mbps) AS MAX_download_Mbps
+  FROM dl_per_location_cleaned
+  GROUP BY date, continent_code, ip
+),
+# Calculate final stats per day from 1x test per ip per day normalization in prev. step
+dl_stats_per_day AS (
+  SELECT
+    date,
+    continent_code,
+    MIN(MIN_download_Mbps) AS MIN_download_Mbps,
+    APPROX_QUANTILES(LOWER_QUART_download_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
+    APPROX_QUANTILES(MED_download_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
+    AVG(MEAN_download_Mbps) AS MEAN_download_Mbps,
+    APPROX_QUANTILES(UPPER_QUART_download_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
+    MAX(MAX_download_Mbps) AS MAX_download_Mbps
+  FROM
+    dl_stats_perip_perday
+  GROUP BY date, continent_code
+),
+dl_total_samples_per_geo AS (
+  SELECT
+    date,
+    COUNT(*) AS dl_total_samples,
+    continent_code
+  FROM dl_per_location_cleaned
+  GROUP BY date, continent_code
+),
+# Now generate daily histograms of Max DL
+max_dl_per_day_ip AS (
+  SELECT
+    date,
+    continent_code,
+    ip,
+    MAX(mbps) AS mbps
+  FROM dl_per_location_cleaned
+  GROUP BY
+    date,
+    continent_code,
+    ip
+),
+# Count the samples
+dl_sample_counts AS (
+  SELECT
+    date,
+    continent_code,
+    COUNT(*) AS samples
+  FROM max_dl_per_day_ip
+  GROUP BY
+    date,
+    continent_code
+),
+# Generate equal sized buckets in log-space
+buckets AS (
+  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
+  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+),
+# Count the samples that fall into each bucket
+dl_histogram_counts AS (
+  SELECT
+    date,
+    continent_code,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
+  FROM max_dl_per_day_ip CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
+    bucket_min,
+    bucket_max
+),
+# Turn the counts into frequencies
+dl_histogram AS (
+  SELECT
+    date,
+    continent_code,
+    bucket_min,
+    bucket_max,
+    bucket_count / samples AS dl_frac,
+    samples AS dl_samples
+  FROM dl_histogram_counts
+  JOIN dl_sample_counts USING (date, continent_code)
+),
+# Repeat for Upload tests
+# Select the initial set of upload results
+ul_per_location AS (
+  SELECT
+    date,
+    client.Geo.continent_code AS continent_code,
+    a.MeanThroughputMbps AS mbps,
+    NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
+  FROM `measurement-lab.ndt.unified_uploads`
+  WHERE date BETWEEN @startdate AND @enddate
+  AND a.MeanThroughputMbps != 0
+),
+# With good locations and valid IPs
+ul_per_location_cleaned AS (
+  SELECT
+    date,
+    continent_code,
+    mbps,
+    ip
+  FROM ul_per_location
+  WHERE
+    continent_code IS NOT NULL AND continent_code != ""
+    AND ip IS NOT NULL
+),
+# Gather descriptive statistics per geo, day, per ip
+ul_stats_perip_perday AS (
+  SELECT
+    date,
+    continent_code,
+    ip,
+    MIN(mbps) AS MIN_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_upload_Mbps,
+    AVG(mbps) AS MEAN_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_upload_Mbps,
+    MAX(mbps) AS MAX_upload_Mbps
+  FROM ul_per_location_cleaned
+  GROUP BY date, continent_code, ip
+),
+# Calculate final stats per day from 1x test per ip per day normalization in prev. step
+ul_stats_per_day AS (
+  SELECT
+    date,
+    continent_code,
+    MIN(MIN_upload_Mbps) AS MIN_upload_Mbps,
+    APPROX_QUANTILES(LOWER_QUART_upload_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_upload_Mbps,
+    APPROX_QUANTILES(MED_upload_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_upload_Mbps,
+    AVG(MEAN_upload_Mbps) AS MEAN_upload_Mbps,
+    APPROX_QUANTILES(UPPER_QUART_upload_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_upload_Mbps,
+    MAX(MAX_upload_Mbps) AS MAX_upload_Mbps
+  FROM
+    ul_stats_perip_perday
+  GROUP BY date, continent_code
+),
+ul_total_samples_per_geo AS (
+  SELECT
+    date,
+    COUNT(*) AS ul_total_samples,
+    continent_code,
+  FROM ul_per_location_cleaned
+  GROUP BY date, continent_code
+),
+# Now generate daily histograms of Max UL
+max_ul_per_day_ip AS (
+  SELECT
+    date,
+    continent_code,
+    ip,
+    MAX(mbps) AS mbps
+  FROM ul_per_location_cleaned
+  GROUP BY
+    date,
+    continent_code,
+    ip
+),
+# Count the samples
+ul_sample_counts AS (
+  SELECT
+    date,
+    continent_code,
+    COUNT(*) AS samples
+  FROM max_ul_per_day_ip
+  GROUP BY
+    date,
+    continent_code
+),
+# Count the samples that fall into each bucket
+ul_histogram_counts AS (
+  SELECT
+    date,
+    continent_code,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
+  FROM max_ul_per_day_ip CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
+    bucket_min,
+    bucket_max
+),
+# Turn the counts into frequencies
+ul_histogram AS (
+  SELECT
+    date,
+    continent_code,
+    bucket_min,
+    bucket_max,
+    bucket_count / samples AS ul_frac,
+    samples AS ul_samples
+  FROM ul_histogram_counts
+  JOIN ul_sample_counts USING (date, continent_code)
+)
+# Show the results
+SELECT * FROM dl_histogram
+JOIN ul_histogram USING (date, continent_code, bucket_min, bucket_max)
+JOIN dl_stats_per_day USING (date, continent_code)
+JOIN dl_total_samples_per_geo USING (date, continent_code)
+JOIN ul_stats_per_day USING (date, continent_code)
+JOIN ul_total_samples_per_geo USING (date, continent_code)
+ORDER BY date, continent_code, bucket_min, bucket_max

--- a/statistics/queries/us_census_tracts_histogram.sql
+++ b/statistics/queries/us_census_tracts_histogram.sql
@@ -10,15 +10,6 @@ tracts AS (
   FROM
     `bigquery-public-data.geo_census_tracts.us_census_tracts_national`
 ),
-tracts_noWKT AS (
-  SELECT
-    state_name,
-    tract_name,
-    lsad_name,
-    CAST(geo_id AS STRING) AS GEOID
-  FROM
-    `bigquery-public-data.geo_census_tracts.us_census_tracts_national`
-),
 dl AS (
   SELECT
     date,
@@ -387,5 +378,3 @@ JOIN dl_stats_perday USING (date, state, state_name, tract_name, lsad_name, GEOI
 JOIN dl_total_samples_pergeo_perday USING (date, state, state_name, tract_name, lsad_name, GEOID)
 JOIN ul_stats_perday USING (date, state, state_name, tract_name, lsad_name, GEOID)
 JOIN ul_total_samples_pergeo_perday USING (date, state, state_name, tract_name, lsad_name, GEOID)
-JOIN tracts_noWKT USING (GEOID)
-ORDER BY date, state, dl_histogram.state_name, dl_histogram.tract_name, dl_histogram.lsad_name, GEOID, bucket_min, bucket_max

--- a/statistics/queries/us_county_histogram.sql
+++ b/statistics/queries/us_county_histogram.sql
@@ -282,4 +282,3 @@ JOIN dl_total_samples_pergeo_perday USING (date, state, GEOID)
 JOIN ul_stats_perday USING (date, state, GEOID)
 JOIN ul_total_samples_pergeo_perday USING (date, state, GEOID)
 JOIN counties_noWKT USING (GEOID)
-ORDER BY date, state, GEOID, bucket_min, bucket_max

--- a/statistics/queries/us_county_histogram.sql
+++ b/statistics/queries/us_county_histogram.sql
@@ -1,0 +1,285 @@
+#standardSQL
+WITH
+counties AS (
+  SELECT
+    county_name,
+    county_geom AS WKT,
+    geo_id AS GEOID
+  FROM
+    `bigquery-public-data.geo_us_boundaries.counties`
+),
+counties_noWKT AS (
+  SELECT
+    county_name,
+    geo_id AS GEOID
+  FROM
+    `bigquery-public-data.geo_us_boundaries.counties`
+),
+dl AS (
+  SELECT
+    date,
+    counties.GEOID AS GEOID,
+    CONCAT(client.Geo.country_code,"-",client.Geo.region) AS state,
+    NET.SAFE_IP_FROM_STRING(client.IP) AS ip,
+    a.MeanThroughputMbps AS mbps,
+    a.MinRTT AS MinRTT
+  FROM
+    `measurement-lab.ndt.unified_downloads` tests, counties
+  WHERE
+    date BETWEEN @startdate AND @enddate
+    AND client.Geo.country_name = "United States"
+    AND client.Geo.country_code IS NOT NULL
+    AND client.Geo.country_code != ""
+    AND client.Geo.region IS NOT NULL
+    AND client.Geo.region != ""
+    AND ST_WITHIN(
+      ST_GeogPoint(
+        client.Geo.longitude,
+        client.Geo.latitude
+      ), counties.WKT
+    )
+    AND a.MeanThroughputMbps != 0
+),
+dl_stats_perip_perday AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    ip,
+    MIN(mbps) AS download_MIN,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS download_Q25,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS download_MED,
+    AVG(mbps) AS download_AVG,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS download_Q75,
+    MAX(mbps) AS download_MAX
+  FROM dl
+  GROUP BY date, state, GEOID, ip
+),
+dl_stats_perday AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    MIN(download_MIN) AS download_MIN,
+    APPROX_QUANTILES(download_Q25, 100) [SAFE_ORDINAL(25)] AS download_Q25,
+    APPROX_QUANTILES(download_MED, 100) [SAFE_ORDINAL(50)] AS download_MED,
+    AVG(download_AVG) AS download_AVG,
+    APPROX_QUANTILES(download_Q75, 100) [SAFE_ORDINAL(75)] AS download_Q75,
+    MAX(download_MAX) AS download_MAX
+  FROM dl_stats_perip_perday
+  GROUP BY date, state, GEOID
+),
+dl_total_samples_pergeo_perday AS (
+  SELECT
+    date,
+    COUNT(*) AS dl_total_samples,
+    state,
+    GEOID
+  FROM dl
+  GROUP BY date, state, GEOID
+),
+#############
+ul AS (
+  SELECT
+    date,
+    counties.GEOID AS GEOID,
+    CONCAT(client.Geo.country_code,"-",client.Geo.region) AS state,
+    NET.SAFE_IP_FROM_STRING(client.IP) AS ip,
+    a.MeanThroughputMbps AS mbps,
+    a.MinRTT AS MinRTT
+  FROM
+    `measurement-lab.ndt.unified_uploads` tests, counties
+  WHERE
+    date BETWEEN @startdate AND @enddate
+    AND client.Geo.country_name = "United States"
+    AND client.Geo.country_code IS NOT NULL
+    AND client.Geo.country_code != ""
+    AND client.Geo.region IS NOT NULL
+    AND client.Geo.region != ""
+    AND ST_WITHIN(
+      ST_GeogPoint(
+        client.Geo.longitude,
+        client.Geo.latitude
+      ), counties.WKT
+    )
+    AND a.MeanThroughputMbps != 0
+),
+ul_stats_perip_perday AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    ip,
+    MIN(mbps) AS upload_MIN,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS upload_Q25,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS upload_MED,
+    AVG(mbps) AS upload_AVG,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS upload_Q75,
+    MAX(mbps) AS upload_MAX
+  FROM ul
+  GROUP BY date, state, GEOID, ip
+),
+ul_stats_perday AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    MIN(upload_MIN) AS upload_MIN,
+    APPROX_QUANTILES(upload_Q25, 100) [SAFE_ORDINAL(25)] AS upload_Q25,
+    APPROX_QUANTILES(upload_MED, 100) [SAFE_ORDINAL(50)] AS upload_MED,
+    AVG(upload_AVG) AS upload_AVG,
+    APPROX_QUANTILES(upload_Q75, 100) [SAFE_ORDINAL(75)] AS upload_Q75,
+    MAX(upload_MAX) AS upload_MAX
+  FROM ul_stats_perip_perday
+  GROUP BY date, state, GEOID
+),
+ul_total_samples_pergeo_perday AS (
+  SELECT
+    date,
+    COUNT(*) AS ul_total_samples,
+    state,
+    GEOID
+  FROM ul
+  GROUP BY date, state, GEOID
+),
+# Now generate the daily histograms of the Maximum measured download speed, per IP, per day.
+
+# First, select the MAX download metric and geo fields from the original cleaned data.
+max_dl_per_day_ip AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    ip,
+    MAX(mbps) AS download_MAX
+  FROM dl
+  GROUP BY
+    date,
+    state,
+    GEOID,
+    ip
+),
+# Count the samples for the daily histogram of Max dowload tests.
+#   The counts here are drawn from: dl_stats_perip_perday > max_dl_per_day_ip
+#   and therefore represent the **one** MAX download value per IP on that day.
+#
+#   This count is different from "dl_total_samples_pergeo_perday" because the
+#   histogram is meant to communicate the number of **testers** who could or could
+#   not reach specific bucket thresholds, while dl_total_samples_pergeo_perday
+#   is the count of **all tests** from all IPs in the sample on that day.
+dl_sample_counts AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    COUNT(*) AS samples
+  FROM max_dl_per_day_ip
+  GROUP BY
+    date,
+    state,
+    GEOID
+),
+# Generate equal sized buckets in log-space. This returns 21 buckets pergeo perday from 0.63 to 10000.
+# Five steps per logarithmic decade, from 0.63 to 10000, i.e. 0.63, 1.0, 1.58, 2.51, 3.98, 6.30, 10.0, ...
+
+buckets AS (
+  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
+  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+),
+# Count the samples that fall into each bucket
+dl_histogram_counts AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(download_MAX BETWEEN bucket_left AND bucket_right) AS bucket_count
+  FROM max_dl_per_day_ip CROSS JOIN buckets
+  GROUP BY
+    date,
+    state,
+    GEOID,
+    bucket_min,
+    bucket_max
+),
+# Turn the counts into frequencies
+dl_histogram AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    bucket_min,
+    bucket_max,
+    bucket_count / samples AS dl_frac,
+    samples AS dl_samples
+  FROM dl_histogram_counts
+  JOIN dl_sample_counts USING (date, state, GEOID)
+),
+# Generate histogram for uploads
+max_ul_per_day_ip AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    ip,
+    MAX(mbps) AS upload_MAX
+  FROM ul
+  GROUP BY
+    date,
+    state,
+    GEOID,
+    ip
+),
+# Count the samples
+ul_sample_counts AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    COUNT(*) AS samples
+  FROM max_ul_per_day_ip
+  GROUP BY
+    date,
+    state,
+    GEOID
+),
+# Count the samples that fall into each bucket
+ul_histogram_counts AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(upload_MAX BETWEEN bucket_left AND bucket_right) AS bucket_count
+  FROM max_ul_per_day_ip CROSS JOIN buckets
+  GROUP BY
+    date,
+    state,
+    GEOID,
+    bucket_min,
+    bucket_max
+),
+# Turn the counts into frequencies
+ul_histogram AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    bucket_min,
+    bucket_max,
+    bucket_count / samples AS ul_frac,
+    samples AS ul_samples
+  FROM ul_histogram_counts
+  JOIN ul_sample_counts USING (date, state, GEOID)
+)
+# Show the results
+SELECT * FROM dl_histogram
+JOIN ul_histogram USING (date, state, GEOID, bucket_min, bucket_max)
+JOIN dl_stats_perday USING (date, state, GEOID)
+JOIN dl_total_samples_pergeo_perday USING (date, state, GEOID)
+JOIN ul_stats_perday USING (date, state, GEOID)
+JOIN ul_total_samples_pergeo_perday USING (date, state, GEOID)
+JOIN counties_noWKT USING (GEOID)
+ORDER BY date, state, GEOID, bucket_min, bucket_max


### PR DESCRIPTION
This PR updates the region query with new bucket generating code and excludes results where Mbps=0
The new bucket generating sub-query now returns 46 buckets, the first beginning at 0.00000630957

As of today, ~13539 download tests have Mbps=0, and ~169 tests between 0 and 0.00006, so if we exclude tests = 0 and start the first bucket at 0.000006... we should be including all relevant tests in the histogram without having to manually generate the buckets.

This PR also adds the continent, country, and city queries for inclusion in the stats-pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/9)
<!-- Reviewable:end -->
