### PR TITLE
Correct query counts

### DIFF
--- a/statistics/queries/continent_country_histogram.sql
+++ b/statistics/queries/continent_country_histogram.sql
@@ -1,11 +1,15 @@
 WITH
+# Generate equal sized buckets in log-space between near 0 and 10Gbps
+buckets AS (
+  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
+  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+),
 # Select the initial set of results
 dl_per_location AS (
   SELECT
     date,
     client.Geo.continent_code AS continent_code,
     client.Geo.country_code AS country_code,
-    client.Geo.country_name AS country_name,
     a.MeanThroughputMbps AS mbps,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
   FROM `measurement-lab.ndt.unified_downloads`
@@ -18,14 +22,12 @@ dl_per_location_cleaned AS (
     date,
     continent_code,
     country_code,
-    country_name,
     mbps,
     ip
   FROM dl_per_location
   WHERE
     continent_code IS NOT NULL AND continent_code != ""
     AND country_code IS NOT NULL AND country_code != ""
-    AND country_name IS NOT NULL AND country_name != ""
     AND ip IS NOT NULL
 ),
 # Gather descriptive statistics per geo, day, per ip
@@ -34,7 +36,6 @@ dl_stats_perip_perday AS (
     date,
     continent_code,
     country_code,
-    country_name,
     ip,
     MIN(mbps) AS download_MIN,
     APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS download_Q25,
@@ -43,7 +44,7 @@ dl_stats_perip_perday AS (
     APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS download_Q75,
     MAX(mbps) AS download_MAX
   FROM dl_per_location_cleaned
-  GROUP BY date, continent_code, country_code, country_name, ip
+  GROUP BY date, continent_code, country_code, ip
 ),
 # Calculate final stats per day from 1x test per ip per day normalization in prev. step
 dl_stats_per_day AS (
@@ -51,7 +52,7 @@ dl_stats_per_day AS (
     date,
     continent_code,
     country_code,
-    country_name,
+    COUNT(*) AS download_samples_stats_per_day,
     MIN(download_MIN) AS download_MIN,
     APPROX_QUANTILES(download_Q25, 100) [SAFE_ORDINAL(25)] AS download_Q25,
     APPROX_QUANTILES(download_MED, 100) [SAFE_ORDINAL(50)] AS download_MED,
@@ -60,87 +61,52 @@ dl_stats_per_day AS (
     MAX(download_MAX) AS download_MAX
   FROM
     dl_stats_perip_perday
-  GROUP BY date, continent_code, country_code, country_name
+  GROUP BY date, continent_code, country_code
 ),
-dl_total_samples_per_geo AS (
+# Count the difference in the number of tests from the same IPs on the same
+#   day, to the number of tests used in the daily statistics.
+dl_samples_total AS (
   SELECT
-    date,
     COUNT(*) AS dl_total_samples,
-    continent_code,
-    country_code,
-    country_name
-  FROM dl_per_location_cleaned
-  GROUP BY date, continent_code, country_code, country_name
-),
-# Now generate daily histograms of Max DL
-max_dl_per_day_ip AS (
-  SELECT
     date,
     continent_code,
-    country_code,
-    country_name,
-    ip,
-    MAX(mbps) AS mbps
+    country_code
   FROM dl_per_location_cleaned
   GROUP BY
     date,
     continent_code,
-    country_code,
-    country_name,
-    ip
+    country_code
 ),
-# Count the samples
-dl_sample_counts AS (
+dl_samples_stats AS (
   SELECT
+    COUNT(*) AS dl_stats_samples,
     date,
     continent_code,
-    country_code,
-    country_name,
-    COUNT(*) AS samples
-  FROM max_dl_per_day_ip
+    country_code
+  FROM dl_stats_perip_perday
   GROUP BY
     date,
     continent_code,
-    country_code,
-    country_name
+    country_code
 ),
-# Generate equal sized buckets in log-space
-buckets AS (
-  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
-  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
-),
-# Count the samples that fall into each bucket
-dl_histogram_counts AS (
-  SELECT
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    bucket_left AS bucket_min,
-    bucket_right AS bucket_max,
-    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
-  FROM max_dl_per_day_ip CROSS JOIN buckets
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    bucket_min,
-    bucket_max
-),
-# Turn the counts into frequencies
+# Count the samples that fall into each bucket and get frequencies
 dl_histogram AS (
   SELECT
     date,
     continent_code,
     country_code,
-    country_name,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) AS dl_samples_bucket,
+    COUNT(*) AS dl_samples_day,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) / COUNT(*) AS dl_frac
+  FROM dl_stats_perip_perday CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
     bucket_min,
-    bucket_max,
-    bucket_count / samples AS dl_frac,
-    samples AS dl_samples
-  FROM dl_histogram_counts
-  JOIN dl_sample_counts USING (date, continent_code, country_code, country_name)
+    bucket_max
 ),
 # Repeat for Upload tests
 # Select the initial set of upload results
@@ -149,7 +115,6 @@ ul_per_location AS (
     date,
     client.Geo.continent_code AS continent_code,
     client.Geo.country_code AS country_code,
-    client.Geo.country_name AS country_name,
     a.MeanThroughputMbps AS mbps,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
   FROM `measurement-lab.ndt.unified_uploads`
@@ -162,14 +127,12 @@ ul_per_location_cleaned AS (
     date,
     continent_code,
     country_code,
-    country_name,
     mbps,
     ip
   FROM ul_per_location
   WHERE
     continent_code IS NOT NULL AND continent_code != ""
     AND country_code IS NOT NULL AND country_code != ""
-    AND country_name IS NOT NULL AND country_name != ""
     AND ip IS NOT NULL
 ),
 # Gather descriptive statistics per geo, day, per ip
@@ -178,7 +141,6 @@ ul_stats_perip_perday AS (
     date,
     continent_code,
     country_code,
-    country_name,
     ip,
     MIN(mbps) AS upload_MIN,
     APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS upload_Q25,
@@ -187,7 +149,7 @@ ul_stats_perip_perday AS (
     APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS upload_Q75,
     MAX(mbps) AS upload_MAX
   FROM ul_per_location_cleaned
-  GROUP BY date, continent_code, country_code, country_name, ip
+  GROUP BY date, continent_code, country_code, ip
 ),
 # Calculate final stats per day from 1x test per ip per day normalization in prev. step
 ul_stats_per_day AS (
@@ -195,7 +157,7 @@ ul_stats_per_day AS (
     date,
     continent_code,
     country_code,
-    country_name,
+    COUNT(*) AS upload_samples_stats_per_day,
     MIN(upload_MIN) AS upload_MIN,
     APPROX_QUANTILES(upload_Q25, 100) [SAFE_ORDINAL(25)] AS upload_Q25,
     APPROX_QUANTILES(upload_MED, 100) [SAFE_ORDINAL(50)] AS upload_MED,
@@ -204,88 +166,59 @@ ul_stats_per_day AS (
     MAX(upload_MAX) AS upload_MAX
   FROM
     ul_stats_perip_perday
-  GROUP BY date, continent_code, country_code, country_name
+  GROUP BY date, continent_code, country_code
 ),
-ul_total_samples_per_geo AS (
+# Show the total number of samples (all tests from all IPs)
+ul_samples_total AS (
   SELECT
-    date,
     COUNT(*) AS ul_total_samples,
-    continent_code,
-    country_code,
-    country_name
-  FROM ul_per_location_cleaned
-  GROUP BY date, continent_code, country_code, country_name
-),
-# Now generate daily histograms of Max UL
-max_ul_per_day_ip AS (
-  SELECT
     date,
     continent_code,
-    country_code,
-    country_name,
-    ip,
-    MAX(mbps) AS mbps
+    country_code
   FROM ul_per_location_cleaned
   GROUP BY
     date,
     continent_code,
-    country_code,
-    country_name,
-    ip
+    country_code
 ),
-# Count the samples
-ul_sample_counts AS (
+# Show the number of samples used in the statistics (one per IP per day)
+ul_samples_stats AS (
   SELECT
+    COUNT(*) AS ul_stats_samples,
     date,
     continent_code,
-    country_code,
-    country_name,
-    COUNT(*) AS samples
-  FROM max_ul_per_day_ip
+    country_code
+  FROM ul_stats_perip_perday
   GROUP BY
     date,
     continent_code,
-    country_code,
-    country_name
+    country_code
 ),
-# Count the samples that fall into each bucket
-ul_histogram_counts AS (
-  SELECT
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    bucket_left AS bucket_min,
-    bucket_right AS bucket_max,
-    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
-  FROM max_ul_per_day_ip CROSS JOIN buckets
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    bucket_min,
-    bucket_max
-),
-# Turn the counts into frequencies
+# Generate the histogram with samples per bucket and frequencies
 ul_histogram AS (
   SELECT
     date,
     continent_code,
     country_code,
-    country_name,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) AS ul_samples_bucket,
+    COUNT(*) AS ul_samples_day,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) / COUNT(*) AS ul_frac
+  FROM ul_stats_perip_perday CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
     bucket_min,
-    bucket_max,
-    bucket_count / samples AS ul_frac,
-    samples AS ul_samples
-  FROM ul_histogram_counts
-  JOIN ul_sample_counts USING (date, continent_code, country_code, country_name)
+    bucket_max
 )
 # Show the results
 SELECT * FROM dl_histogram
-JOIN ul_histogram USING (date, continent_code, country_code, country_name, bucket_min, bucket_max)
-JOIN dl_stats_per_day USING (date, continent_code, country_code, country_name)
-JOIN dl_total_samples_per_geo USING (date, continent_code, country_code, country_name)
-JOIN ul_stats_per_day USING (date, continent_code, country_code, country_name)
-JOIN ul_total_samples_per_geo USING (date, continent_code, country_code, country_name)
-ORDER BY date, continent_code, country_code, country_name, bucket_min, bucket_max
+JOIN ul_histogram USING (date, continent_code, country_code, bucket_min, bucket_max)
+JOIN dl_stats_per_day USING (date, continent_code, country_code)
+JOIN ul_stats_per_day USING (date, continent_code, country_code)
+JOIN dl_samples_total USING (date, continent_code, country_code)
+JOIN ul_samples_total USING (date, continent_code, country_code)
+JOIN dl_samples_stats USING (date, continent_code, country_code)
+JOIN ul_samples_stats USING (date, continent_code, country_code)

--- a/statistics/queries/continent_country_region_city_histogram.sql
+++ b/statistics/queries/continent_country_region_city_histogram.sql
@@ -10,7 +10,6 @@ dl_per_location AS (
     date,
     client.Geo.continent_code AS continent_code,
     client.Geo.country_code AS country_code,
-    client.Geo.country_name AS country_name,
     CONCAT(client.Geo.country_code, '-', client.Geo.region) AS ISO3166_2region1,
     client.Geo.city AS city,
     a.MeanThroughputMbps AS mbps,

--- a/statistics/queries/continent_country_region_histogram.sql
+++ b/statistics/queries/continent_country_region_histogram.sql
@@ -1,5 +1,10 @@
 WITH
-# Select the initial set of download test results
+# Generate equal sized buckets in log-space between near 0 and 10Gbps
+buckets AS (
+  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
+  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+),
+# Select the initial set of results
 dl_per_location AS (
   SELECT
     date,
@@ -11,17 +16,14 @@ dl_per_location AS (
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
   FROM `measurement-lab.ndt.unified_downloads`
   WHERE date BETWEEN @startdate AND @enddate
-  AND client.geo.region != ""
-  AND client.geo.region IS NOT NULL
   AND a.MeanThroughputMbps != 0
 ),
-# Clean the initial set of results so we're only using those with good location values and valid IPs
+# With good locations and valid IPs
 dl_per_location_cleaned AS (
   SELECT
     date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1,
     mbps,
     ip
@@ -29,7 +31,6 @@ dl_per_location_cleaned AS (
   WHERE
     continent_code IS NOT NULL AND continent_code != ""
     AND country_code IS NOT NULL AND country_code != ""
-    AND country_name IS NOT NULL AND country_name != ""
     AND ISO3166_2region1 IS NOT NULL AND ISO3166_2region1 != ""
     AND ip IS NOT NULL
 ),
@@ -39,7 +40,6 @@ dl_stats_perip_perday AS (
     date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1,
     ip,
     MIN(mbps) AS download_MIN,
@@ -49,142 +49,76 @@ dl_stats_perip_perday AS (
     APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS download_Q75,
     MAX(mbps) AS download_MAX
   FROM dl_per_location_cleaned
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1,
-    ip
+  GROUP BY date, continent_code, country_code, ISO3166_2region1, ip
 ),
 # Calculate final stats per day from 1x test per ip per day normalization in prev. step
-dl_stats_perday AS (
+dl_stats_per_day AS (
   SELECT
     date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1,
+    COUNT(*) AS download_samples_stats_per_day,
     MIN(download_MIN) AS download_MIN,
     APPROX_QUANTILES(download_Q25, 100) [SAFE_ORDINAL(25)] AS download_Q25,
     APPROX_QUANTILES(download_MED, 100) [SAFE_ORDINAL(50)] AS download_MED,
-    AVG(download_MED) AS download_AVG,
+    AVG(download_AVG) AS download_AVG,
     APPROX_QUANTILES(download_Q75, 100) [SAFE_ORDINAL(75)] AS download_Q75,
     MAX(download_MAX) AS download_MAX
   FROM
     dl_stats_perip_perday
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1
+  GROUP BY date, continent_code, country_code, ISO3166_2region1
 ),
-# Total samples pergeo perday counts ALL tests in the day, from the original cleaned data.
-dl_total_samples_pergeo_perday AS (
+# Count the difference in the number of tests from the same IPs on the same
+#   day, to the number of tests used in the daily statistics.
+dl_samples_total AS (
   SELECT
-    date,
     COUNT(*) AS dl_total_samples,
+    date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1
   FROM dl_per_location_cleaned
   GROUP BY
     date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1
 ),
-# Now generate the daily histograms of the Maximum measured download speed, per IP, per day.
-
-# First, select the MAX download metric and geo fields from the original cleaned data.
-max_dl_per_day_ip AS (
+dl_samples_stats AS (
   SELECT
+    COUNT(*) AS dl_stats_samples,
     date,
     continent_code,
     country_code,
-    country_name,
-    ISO3166_2region1,
-    ip,
-    MAX(mbps) AS download_MAX
-  FROM dl_per_location_cleaned
+    ISO3166_2region1
+  FROM dl_stats_perip_perday
   GROUP BY
     date,
     continent_code,
     country_code,
-    country_name,
-    ISO3166_2region1,
-    ip
-),
-# Count the samples for the daily histogram of Max dowload tests.
-#   The counts here are drawn from: dl_stats_perip_perday > max_dl_per_day_ip
-#   and therefore represent the **one** MAX download value per IP on that day.
-#
-#   This count is different from "dl_total_samples_pergeo_perday" because the
-#   histogram is meant to communicate the number of **testers** who could or could
-#   not reach specific bucket thresholds, while dl_total_samples_pergeo_perday
-#   is the count of **all tests** from all IPs in the sample on that day.
-dl_sample_counts AS (
-  SELECT
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1,
-    COUNT(*) AS samples
-  FROM max_dl_per_day_ip
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
     ISO3166_2region1
 ),
-# Generate equal sized buckets in log-space. This returns 21 buckets pergeo perday from 0.63 to 10000.
-# Five steps per logarithmic decade, from 0.63 to 10000, i.e. 0.63, 1.0, 1.58, 2.51, 3.98, 6.30, 10.0, ...
-
-buckets AS (
-  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
-  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
-),
-# Count the samples that fall into each bucket
-dl_histogram_counts AS (
-  SELECT
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1,
-    bucket_left AS bucket_min,
-    bucket_right AS bucket_max,
-    COUNTIF(download_MAX BETWEEN bucket_left AND bucket_right) AS bucket_count
-  FROM max_dl_per_day_ip CROSS JOIN buckets
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1,
-    bucket_min,
-    bucket_max
-),
-# Turn the counts into frequencies
+# Count the samples that fall into each bucket and get frequencies
 dl_histogram AS (
   SELECT
     date,
     continent_code,
     country_code,
-    country_name,
+    ISO3166_2region1,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) AS dl_samples_bucket,
+    COUNT(*) AS dl_samples_day,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) / COUNT(*) AS fl_frac
+  FROM dl_stats_perip_perday CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
     ISO3166_2region1,
     bucket_min,
-    bucket_max,
-    bucket_count / samples AS dl_frac,
-    samples AS dl_samples
-  FROM dl_histogram_counts
-  JOIN dl_sample_counts USING (date, continent_code, country_code,
-                            country_name, ISO3166_2region1)
+    bucket_max
 ),
 # Repeat for Upload tests
 # Select the initial set of upload results
@@ -193,14 +127,11 @@ ul_per_location AS (
     date,
     client.Geo.continent_code AS continent_code,
     client.Geo.country_code AS country_code,
-    client.Geo.country_name AS country_name,
     CONCAT(client.Geo.country_code, '-', client.Geo.region) AS ISO3166_2region1,
     a.MeanThroughputMbps AS mbps,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
   FROM `measurement-lab.ndt.unified_uploads`
   WHERE date BETWEEN @startdate AND @enddate
-  AND client.geo.region != ""
-  AND client.geo.region IS NOT NULL
   AND a.MeanThroughputMbps != 0
 ),
 # With good locations and valid IPs
@@ -209,7 +140,6 @@ ul_per_location_cleaned AS (
     date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1,
     mbps,
     ip
@@ -217,7 +147,6 @@ ul_per_location_cleaned AS (
   WHERE
     continent_code IS NOT NULL AND continent_code != ""
     AND country_code IS NOT NULL AND country_code != ""
-    AND country_name IS NOT NULL AND country_name != ""
     AND ISO3166_2region1 IS NOT NULL AND ISO3166_2region1 != ""
     AND ip IS NOT NULL
 ),
@@ -227,7 +156,6 @@ ul_stats_perip_perday AS (
     date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1,
     ip,
     MIN(mbps) AS upload_MIN,
@@ -236,131 +164,84 @@ ul_stats_perip_perday AS (
     AVG(mbps) AS upload_AVG,
     APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS upload_Q75,
     MAX(mbps) AS upload_MAX
-  FROM dl_per_location_cleaned
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1,
-    ip
+  FROM ul_per_location_cleaned
+  GROUP BY date, continent_code, country_code, ISO3166_2region1, ip
 ),
 # Calculate final stats per day from 1x test per ip per day normalization in prev. step
-ul_stats_perday AS (
+ul_stats_per_day AS (
   SELECT
     date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1,
+    COUNT(*) AS upload_samples_stats_per_day,
     MIN(upload_MIN) AS upload_MIN,
     APPROX_QUANTILES(upload_Q25, 100) [SAFE_ORDINAL(25)] AS upload_Q25,
     APPROX_QUANTILES(upload_MED, 100) [SAFE_ORDINAL(50)] AS upload_MED,
-    AVG(upload_MED) AS upload_AVG,
+    AVG(upload_AVG) AS upload_AVG,
     APPROX_QUANTILES(upload_Q75, 100) [SAFE_ORDINAL(75)] AS upload_Q75,
     MAX(upload_MAX) AS upload_MAX
   FROM
     ul_stats_perip_perday
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1
+  GROUP BY date, continent_code, country_code, ISO3166_2region1
 ),
-ul_total_samples_pergeo_perday AS (
+# Show the total number of samples (all tests from all IPs)
+ul_samples_total AS (
   SELECT
-    date,
     COUNT(*) AS ul_total_samples,
+    date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1
   FROM ul_per_location_cleaned
   GROUP BY
     date,
     continent_code,
     country_code,
-    country_name,
     ISO3166_2region1
 ),
-# Now generate the daily histograms of the Maximum measured upload speed, per IP, per day.
-max_ul_per_day_ip AS (
+# Show the number of samples used in the statistics (one per IP per day)
+ul_samples_stats AS (
   SELECT
+    COUNT(*) AS ul_stats_samples,
     date,
     continent_code,
     country_code,
-    country_name,
-    ISO3166_2region1,
-    ip,
-    MAX(mbps) AS upload_MAX
-  FROM ul_per_location_cleaned
+    ISO3166_2region1
+  FROM ul_stats_perip_perday
   GROUP BY
     date,
     continent_code,
     country_code,
-    country_name,
-    ISO3166_2region1,
-    ip
-),
-# Count the samples
-ul_sample_counts AS (
-  SELECT
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1,
-    COUNT(*) AS samples
-  FROM max_ul_per_day_ip
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
     ISO3166_2region1
 ),
-# Count the samples that fall into each bucket
-ul_histogram_counts AS (
-  SELECT
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1,
-    bucket_left AS bucket_min,
-    bucket_right AS bucket_max,
-    COUNTIF(upload_MAX BETWEEN bucket_left AND bucket_right) AS bucket_count
-  FROM max_ul_per_day_ip CROSS JOIN buckets
-  GROUP BY
-    date,
-    continent_code,
-    country_code,
-    country_name,
-    ISO3166_2region1,
-    bucket_min,
-    bucket_max
-),
-# Turn the counts into frequencies
+# Generate the histogram with samples per bucket and frequencies
 ul_histogram AS (
   SELECT
     date,
     continent_code,
     country_code,
-    country_name,
+    ISO3166_2region1,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) AS ul_samples_bucket,
+    COUNT(*) AS ul_samples_day,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) / COUNT(*) AS ul_frac
+  FROM ul_stats_perip_perday CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
+    country_code,
     ISO3166_2region1,
     bucket_min,
-    bucket_max,
-    bucket_count / samples AS ul_frac,
-    samples AS ul_samples
-  FROM ul_histogram_counts
-  JOIN ul_sample_counts USING (date, continent_code, country_code,
-                            country_name, ISO3166_2region1)
+    bucket_max
 )
 # Show the results
 SELECT * FROM dl_histogram
-JOIN ul_histogram USING (date, continent_code, country_code, country_name, ISO3166_2region1, bucket_min, bucket_max)
-JOIN dl_stats_perday USING (date, continent_code, country_code, country_name, ISO3166_2region1)
-JOIN dl_total_samples_pergeo_perday USING (date, continent_code, country_code, country_name, ISO3166_2region1)
-JOIN ul_stats_perday USING (date, continent_code, country_code, country_name, ISO3166_2region1)
-JOIN ul_total_samples_pergeo_perday USING (date, continent_code, country_code, country_name, ISO3166_2region1)
+JOIN ul_histogram USING (date, continent_code, country_code, ISO3166_2region1, bucket_min, bucket_max)
+JOIN dl_stats_per_day USING (date, continent_code, country_code, ISO3166_2region1)
+JOIN ul_stats_per_day USING (date, continent_code, country_code, ISO3166_2region1)
+JOIN dl_samples_total USING (date, continent_code, country_code, ISO3166_2region1)
+JOIN ul_samples_total USING (date, continent_code, country_code, ISO3166_2region1)
+JOIN dl_samples_stats USING (date, continent_code, country_code, ISO3166_2region1)
+JOIN ul_samples_stats USING (date, continent_code, country_code, ISO3166_2region1)

--- a/statistics/queries/continent_country_region_histogram.sql
+++ b/statistics/queries/continent_country_region_histogram.sql
@@ -10,7 +10,6 @@ dl_per_location AS (
     date,
     client.Geo.continent_code AS continent_code,
     client.Geo.country_code AS country_code,
-    client.Geo.country_name AS country_name,
     CONCAT(client.Geo.country_code, '-', client.Geo.region) AS ISO3166_2region1,
     a.MeanThroughputMbps AS mbps,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip

--- a/statistics/queries/continent_country_region_histogram.sql
+++ b/statistics/queries/continent_country_region_histogram.sql
@@ -109,7 +109,7 @@ dl_histogram AS (
     bucket_right AS bucket_max,
     COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) AS dl_samples_bucket,
     COUNT(*) AS dl_samples_day,
-    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) / COUNT(*) AS fl_frac
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) / COUNT(*) AS dl_frac
   FROM dl_stats_perip_perday CROSS JOIN buckets
   GROUP BY
     date,

--- a/statistics/queries/continent_histogram.sql
+++ b/statistics/queries/continent_histogram.sql
@@ -1,4 +1,9 @@
 WITH
+# Generate equal sized buckets in log-space between near 0 and 10Gbps
+buckets AS (
+  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
+  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+),
 # Select the initial set of results
 dl_per_location AS (
   SELECT
@@ -42,6 +47,7 @@ dl_stats_per_day AS (
   SELECT
     date,
     continent_code,
+    COUNT(*) AS download_samples_stats_per_day,
     MIN(download_MIN) AS download_MIN,
     APPROX_QUANTILES(download_Q25, 100) [SAFE_ORDINAL(25)] AS download_Q25,
     APPROX_QUANTILES(download_MED, 100) [SAFE_ORDINAL(50)] AS download_MED,
@@ -52,69 +58,44 @@ dl_stats_per_day AS (
     dl_stats_perip_perday
   GROUP BY date, continent_code
 ),
-dl_total_samples_per_geo AS (
+# Count the difference in the number of tests from the same IPs on the same
+#   day, to the number of tests used in the daily statistics.
+dl_samples_total AS (
   SELECT
-    date,
     COUNT(*) AS dl_total_samples,
+    date,
     continent_code
   FROM dl_per_location_cleaned
-  GROUP BY date, continent_code
-),
-# Now generate daily histograms of Max DL
-max_dl_per_day_ip AS (
-  SELECT
-    date,
-    continent_code,
-    ip,
-    MAX(mbps) AS mbps
-  FROM dl_per_location_cleaned
-  GROUP BY
-    date,
-    continent_code,
-    ip
-),
-# Count the samples
-dl_sample_counts AS (
-  SELECT
-    date,
-    continent_code,
-    COUNT(*) AS samples
-  FROM max_dl_per_day_ip
   GROUP BY
     date,
     continent_code
 ),
-# Generate equal sized buckets in log-space
-buckets AS (
-  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
-  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+dl_samples_stats AS (
+  SELECT
+    COUNT(*) AS dl_stats_samples,
+    date,
+    continent_code
+  FROM dl_stats_perip_perday
+  GROUP BY
+    date,
+    continent_code
 ),
-# Count the samples that fall into each bucket
-dl_histogram_counts AS (
+# Count the samples that fall into each bucket and get frequencies
+dl_histogram AS (
   SELECT
     date,
     continent_code,
     bucket_left AS bucket_min,
     bucket_right AS bucket_max,
-    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
-  FROM max_dl_per_day_ip CROSS JOIN buckets
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) AS dl_samples_bucket,
+    COUNT(*) AS dl_samples_day,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) / COUNT(*) AS dl_frac
+  FROM dl_stats_perip_perday CROSS JOIN buckets
   GROUP BY
     date,
     continent_code,
     bucket_min,
     bucket_max
-),
-# Turn the counts into frequencies
-dl_histogram AS (
-  SELECT
-    date,
-    continent_code,
-    bucket_min,
-    bucket_max,
-    bucket_count / samples AS dl_frac,
-    samples AS dl_samples
-  FROM dl_histogram_counts
-  JOIN dl_sample_counts USING (date, continent_code)
 ),
 # Repeat for Upload tests
 # Select the initial set of upload results
@@ -160,6 +141,7 @@ ul_stats_per_day AS (
   SELECT
     date,
     continent_code,
+    COUNT(*) AS upload_samples_stats_per_day,
     MIN(upload_MIN) AS upload_MIN,
     APPROX_QUANTILES(upload_Q25, 100) [SAFE_ORDINAL(25)] AS upload_Q25,
     APPROX_QUANTILES(upload_MED, 100) [SAFE_ORDINAL(50)] AS upload_MED,
@@ -170,69 +152,51 @@ ul_stats_per_day AS (
     ul_stats_perip_perday
   GROUP BY date, continent_code
 ),
-ul_total_samples_per_geo AS (
+# Show the total number of samples (all tests from all IPs)
+ul_samples_total AS (
   SELECT
-    date,
     COUNT(*) AS ul_total_samples,
-    continent_code,
+    date,
+    continent_code
   FROM ul_per_location_cleaned
-  GROUP BY date, continent_code
-),
-# Now generate daily histograms of Max UL
-max_ul_per_day_ip AS (
-  SELECT
-    date,
-    continent_code,
-    ip,
-    MAX(mbps) AS mbps
-  FROM ul_per_location_cleaned
-  GROUP BY
-    date,
-    continent_code,
-    ip
-),
-# Count the samples
-ul_sample_counts AS (
-  SELECT
-    date,
-    continent_code,
-    COUNT(*) AS samples
-  FROM max_ul_per_day_ip
   GROUP BY
     date,
     continent_code
 ),
-# Count the samples that fall into each bucket
-ul_histogram_counts AS (
+# Show the number of samples used in the statistics (one per IP per day)
+ul_samples_stats AS (
+  SELECT
+    COUNT(*) AS ul_stats_samples,
+    date,
+    continent_code
+  FROM ul_stats_perip_perday
+  GROUP BY
+    date,
+    continent_code
+),
+# Generate the histogram with samples per bucket and frequencies
+ul_histogram AS (
   SELECT
     date,
     continent_code,
     bucket_left AS bucket_min,
     bucket_right AS bucket_max,
-    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
-  FROM max_ul_per_day_ip CROSS JOIN buckets
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) AS ul_samples_bucket,
+    COUNT(*) AS ul_samples_day,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) / COUNT(*) AS ul_frac
+  FROM ul_stats_perip_perday CROSS JOIN buckets
   GROUP BY
     date,
     continent_code,
     bucket_min,
     bucket_max
-),
-# Turn the counts into frequencies
-ul_histogram AS (
-  SELECT
-    date,
-    continent_code,
-    bucket_min,
-    bucket_max,
-    bucket_count / samples AS ul_frac,
-    samples AS ul_samples
-  FROM ul_histogram_counts
-  JOIN ul_sample_counts USING (date, continent_code)
 )
 # Show the results
 SELECT * FROM dl_histogram
 JOIN ul_histogram USING (date, continent_code, bucket_min, bucket_max)
 JOIN dl_stats_per_day USING (date, continent_code)
-JOIN dl_total_samples_per_geo USING (date, continent_code)
 JOIN ul_stats_per_day USING (date, continent_code)
-JOIN ul_total_samples_per_geo USING (date, continent_code)
+JOIN dl_samples_total USING (date, continent_code)
+JOIN ul_samples_total USING (date, continent_code)
+JOIN dl_samples_stats USING (date, continent_code)
+JOIN ul_samples_stats USING (date, continent_code)

--- a/statistics/queries/us_census_tracts_histogram.sql
+++ b/statistics/queries/us_census_tracts_histogram.sql
@@ -1,5 +1,10 @@
 #standardSQL
 WITH
+# Generate equal sized buckets in log-space between near 0 and 10Gbps
+buckets AS (
+  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
+  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+),
 tracts AS (
   SELECT
     state_name,
@@ -85,7 +90,9 @@ dl_stats_perday AS (
     lsad_name,
     GEOID
 ),
-dl_total_samples_pergeo_perday AS (
+# Count the difference in the number of tests from the same IPs on the same
+#   day, to the number of tests used in the daily statistics.
+dl_samples_total AS (
   SELECT
     date,
     COUNT(*) AS dl_total_samples,
@@ -102,6 +109,49 @@ dl_total_samples_pergeo_perday AS (
     tract_name,
     lsad_name,
     GEOID
+),
+dl_samples_stats AS (
+  SELECT
+    COUNT(*) AS dl_stats_samples,
+    date,
+    state,
+    state_name,
+    tract_name,
+    lsad_name,
+    GEOID
+  FROM dl_stats_perip_perday
+  GROUP BY
+    date,
+    state,
+    state_name,
+    tract_name,
+    lsad_name,
+    GEOID
+),
+# Count the samples that fall into each bucket and get frequencies
+dl_histogram AS (
+  SELECT
+    date,
+    state,
+    state_name,
+    tract_name,
+    lsad_name,
+    GEOID,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) AS dl_samples_bucket,
+    COUNT(*) AS dl_samples_day,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) / COUNT(*) AS dl_frac
+  FROM dl_stats_perip_perday CROSS JOIN buckets
+  GROUP BY
+    date,
+    state,
+    state_name,
+    tract_name,
+    lsad_name,
+    GEOID,
+    bucket_min,
+    bucket_max
 ),
 #############
 ul AS (
@@ -179,7 +229,7 @@ ul_stats_perday AS (
     lsad_name,
     GEOID
 ),
-ul_total_samples_pergeo_perday AS (
+ul_samples_total AS (
   SELECT
     date,
     COUNT(*) AS ul_total_samples,
@@ -197,47 +247,16 @@ ul_total_samples_pergeo_perday AS (
     lsad_name,
     GEOID
 ),
-# Now generate the daily histograms of the Maximum measured download speed, per IP, per day.
-
-# First, select the MAX download metric and geo fields from the original cleaned data.
-max_dl_per_day_ip AS (
+ul_samples_stats AS (
   SELECT
+    COUNT(*) AS ul_stats_samples,
     date,
     state,
     state_name,
     tract_name,
     lsad_name,
-    GEOID,
-    ip,
-    MAX(mbps) AS download_MAX
-  FROM dl
-  GROUP BY
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    ip
-),
-# Count the samples for the daily histogram of Max dowload tests.
-#   The counts here are drawn from: dl_stats_perip_perday > max_dl_per_day_ip
-#   and therefore represent the **one** MAX download value per IP on that day.
-#
-#   This count is different from "dl_total_samples_pergeo_perday" because the
-#   histogram is meant to communicate the number of **testers** who could or could
-#   not reach specific bucket thresholds, while dl_total_samples_pergeo_perday
-#   is the count of **all tests** from all IPs in the sample on that day.
-dl_sample_counts AS (
-  SELECT
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    COUNT(*) AS samples
-  FROM max_dl_per_day_ip
+    GEOID
+  FROM ul_stats_perip_perday
   GROUP BY
     date,
     state,
@@ -246,116 +265,7 @@ dl_sample_counts AS (
     lsad_name,
     GEOID
 ),
-# Generate equal sized buckets in log-space. This returns 21 buckets pergeo perday from 0.63 to 10000.
-# Five steps per logarithmic decade, from 0.63 to 10000, i.e. 0.63, 1.0, 1.58, 2.51, 3.98, 6.30, 10.0, ...
-
-buckets AS (
-  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
-  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
-),
-# Count the samples that fall into each bucket
-dl_histogram_counts AS (
-  SELECT
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    bucket_left AS bucket_min,
-    bucket_right AS bucket_max,
-    COUNTIF(download_MAX BETWEEN bucket_left AND bucket_right) AS bucket_count
-  FROM max_dl_per_day_ip CROSS JOIN buckets
-  GROUP BY
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    bucket_min,
-    bucket_max
-),
-# Turn the counts into frequencies
-dl_histogram AS (
-  SELECT
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    bucket_min,
-    bucket_max,
-    bucket_count / samples AS dl_frac,
-    samples AS dl_samples
-  FROM dl_histogram_counts
-  JOIN dl_sample_counts USING (date, state, state_name, tract_name, lsad_name, GEOID)
-),
-# Generate histogram for uploads
-max_ul_per_day_ip AS (
-  SELECT
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    ip,
-    MAX(mbps) AS upload_MAX
-  FROM ul
-  GROUP BY
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    ip
-),
-# Count the samples
-ul_sample_counts AS (
-  SELECT
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    COUNT(*) AS samples
-  FROM max_ul_per_day_ip
-  GROUP BY
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID
-),
-# Count the samples that fall into each bucket
-ul_histogram_counts AS (
-  SELECT
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    bucket_left AS bucket_min,
-    bucket_right AS bucket_max,
-    COUNTIF(upload_MAX BETWEEN bucket_left AND bucket_right) AS bucket_count
-  FROM max_ul_per_day_ip CROSS JOIN buckets
-  GROUP BY
-    date,
-    state,
-    state_name,
-    tract_name,
-    lsad_name,
-    GEOID,
-    bucket_min,
-    bucket_max
-),
-# Turn the counts into frequencies
+# Generate the histogram with samples per bucket and frequencies
 ul_histogram AS (
   SELECT
     date,
@@ -364,17 +274,30 @@ ul_histogram AS (
     tract_name,
     lsad_name,
     GEOID,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) AS ul_samples_bucket,
+    COUNT(*) AS ul_samples_day,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) / COUNT(*) AS ul_frac
+  FROM ul_stats_perip_perday CROSS JOIN buckets
+  GROUP BY
+    date,
+    state,
+    state_name,
+    tract_name,
+    lsad_name,
+    GEOID,
     bucket_min,
-    bucket_max,
-    bucket_count / samples AS ul_frac,
-    samples AS ul_samples
-  FROM ul_histogram_counts
-  JOIN ul_sample_counts USING (date, state, state_name, tract_name, lsad_name, GEOID)
+    bucket_max
 )
 # Show the results
 SELECT * FROM dl_histogram
 JOIN ul_histogram USING (date, state, state_name, tract_name, lsad_name, GEOID, bucket_min, bucket_max)
 JOIN dl_stats_perday USING (date, state, state_name, tract_name, lsad_name, GEOID)
-JOIN dl_total_samples_pergeo_perday USING (date, state, state_name, tract_name, lsad_name, GEOID)
 JOIN ul_stats_perday USING (date, state, state_name, tract_name, lsad_name, GEOID)
-JOIN ul_total_samples_pergeo_perday USING (date, state, state_name, tract_name, lsad_name, GEOID)
+JOIN dl_samples_total USING (date, state, state_name, tract_name, lsad_name, GEOID)
+JOIN ul_samples_total USING (date, state, state_name, tract_name, lsad_name, GEOID)
+JOIN dl_samples_stats USING (date, state, state_name, tract_name, lsad_name, GEOID)
+JOIN ul_samples_stats USING (date, state, state_name, tract_name, lsad_name, GEOID)
+ORDER BY date, state, state_name, tract_name, lsad_name, GEOID
+

--- a/statistics/queries/us_county_histogram.sql
+++ b/statistics/queries/us_county_histogram.sql
@@ -198,11 +198,12 @@ ul_samples_stats AS (
     state,
     GEOID
 ),
- Generate the histogram with samples per bucket and frequencies
+# Generate the histogram with samples per bucket and frequencies
 ul_histogram AS (
   SELECT
     date,
-    continent_code,
+    state,
+    GEOID,
     bucket_left AS bucket_min,
     bucket_right AS bucket_max,
     COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) AS ul_samples_bucket,
@@ -211,7 +212,8 @@ ul_histogram AS (
   FROM ul_stats_perip_perday CROSS JOIN buckets
   GROUP BY
     date,
-    continent_code,
+    state,
+    GEOID,
     bucket_min,
     bucket_max
 )
@@ -219,7 +221,9 @@ ul_histogram AS (
 SELECT * FROM dl_histogram
 JOIN ul_histogram USING (date, state, GEOID, bucket_min, bucket_max)
 JOIN dl_stats_perday USING (date, state, GEOID)
-JOIN dl_total_samples_pergeo_perday USING (date, state, GEOID)
 JOIN ul_stats_perday USING (date, state, GEOID)
-JOIN ul_total_samples_pergeo_perday USING (date, state, GEOID)
 JOIN counties_noWKT USING (GEOID)
+JOIN dl_samples_total USING (date, state, GEOID)
+JOIN ul_samples_total USING (date, state, GEOID)
+JOIN dl_samples_stats USING (date, state, GEOID)
+JOIN ul_samples_stats USING (date, state, GEOID)

--- a/statistics/queries/us_county_histogram.sql
+++ b/statistics/queries/us_county_histogram.sql
@@ -1,5 +1,10 @@
 #standardSQL
 WITH
+# Generate equal sized buckets in log-space between near 0 and 10Gbps
+buckets AS (
+  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
+  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
+),
 counties AS (
   SELECT
     county_name,
@@ -69,14 +74,50 @@ dl_stats_perday AS (
   FROM dl_stats_perip_perday
   GROUP BY date, state, GEOID
 ),
-dl_total_samples_pergeo_perday AS (
+# Count the difference in the number of tests from the same IPs on the same
+#   day, to the number of tests used in the daily statistics.
+dl_samples_total AS (
   SELECT
     date,
     COUNT(*) AS dl_total_samples,
     state,
     GEOID
   FROM dl
-  GROUP BY date, state, GEOID
+  GROUP BY
+    date,
+    state,
+    GEOID
+),
+dl_samples_stats AS (
+  SELECT
+    COUNT(*) AS dl_stats_samples,
+    date,
+    state,
+    GEOID
+  FROM dl_stats_perip_perday
+  GROUP BY
+    date,
+    state,
+    GEOID
+),
+# Count the samples that fall into each bucket and get frequencies
+dl_histogram AS (
+  SELECT
+    date,
+    state,
+    GEOID,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) AS dl_samples_bucket,
+    COUNT(*) AS dl_samples_day,
+    COUNTIF(download_MAX < bucket_right AND download_MAX >= bucket_left) / COUNT(*) AS dl_frac
+  FROM dl_stats_perip_perday CROSS JOIN buckets
+  GROUP BY
+    date,
+    state,
+    GEOID,
+    bucket_min,
+    bucket_max
 ),
 #############
 ul AS (
@@ -133,146 +174,46 @@ ul_stats_perday AS (
   FROM ul_stats_perip_perday
   GROUP BY date, state, GEOID
 ),
-ul_total_samples_pergeo_perday AS (
+ul_samples_total AS (
   SELECT
     date,
     COUNT(*) AS ul_total_samples,
     state,
     GEOID
   FROM ul
-  GROUP BY date, state, GEOID
-),
-# Now generate the daily histograms of the Maximum measured download speed, per IP, per day.
-
-# First, select the MAX download metric and geo fields from the original cleaned data.
-max_dl_per_day_ip AS (
-  SELECT
-    date,
-    state,
-    GEOID,
-    ip,
-    MAX(mbps) AS download_MAX
-  FROM dl
-  GROUP BY
-    date,
-    state,
-    GEOID,
-    ip
-),
-# Count the samples for the daily histogram of Max dowload tests.
-#   The counts here are drawn from: dl_stats_perip_perday > max_dl_per_day_ip
-#   and therefore represent the **one** MAX download value per IP on that day.
-#
-#   This count is different from "dl_total_samples_pergeo_perday" because the
-#   histogram is meant to communicate the number of **testers** who could or could
-#   not reach specific bucket thresholds, while dl_total_samples_pergeo_perday
-#   is the count of **all tests** from all IPs in the sample on that day.
-dl_sample_counts AS (
-  SELECT
-    date,
-    state,
-    GEOID,
-    COUNT(*) AS samples
-  FROM max_dl_per_day_ip
   GROUP BY
     date,
     state,
     GEOID
 ),
-# Generate equal sized buckets in log-space. This returns 21 buckets pergeo perday from 0.63 to 10000.
-# Five steps per logarithmic decade, from 0.63 to 10000, i.e. 0.63, 1.0, 1.58, 2.51, 3.98, 6.30, 10.0, ...
-
-buckets AS (
-  SELECT POW(10, x-.2) AS bucket_left, POW(10,x) AS bucket_right
-  FROM UNNEST(GENERATE_ARRAY(-5, 4.2, .2)) AS x
-),
-# Count the samples that fall into each bucket
-dl_histogram_counts AS (
+ul_samples_stats AS (
   SELECT
+    COUNT(*) AS ul_stats_samples,
     date,
     state,
-    GEOID,
-    bucket_left AS bucket_min,
-    bucket_right AS bucket_max,
-    COUNTIF(download_MAX BETWEEN bucket_left AND bucket_right) AS bucket_count
-  FROM max_dl_per_day_ip CROSS JOIN buckets
-  GROUP BY
-    date,
-    state,
-    GEOID,
-    bucket_min,
-    bucket_max
-),
-# Turn the counts into frequencies
-dl_histogram AS (
-  SELECT
-    date,
-    state,
-    GEOID,
-    bucket_min,
-    bucket_max,
-    bucket_count / samples AS dl_frac,
-    samples AS dl_samples
-  FROM dl_histogram_counts
-  JOIN dl_sample_counts USING (date, state, GEOID)
-),
-# Generate histogram for uploads
-max_ul_per_day_ip AS (
-  SELECT
-    date,
-    state,
-    GEOID,
-    ip,
-    MAX(mbps) AS upload_MAX
-  FROM ul
-  GROUP BY
-    date,
-    state,
-    GEOID,
-    ip
-),
-# Count the samples
-ul_sample_counts AS (
-  SELECT
-    date,
-    state,
-    GEOID,
-    COUNT(*) AS samples
-  FROM max_ul_per_day_ip
+    GEOID
+  FROM ul_stats_perip_perday
   GROUP BY
     date,
     state,
     GEOID
 ),
-# Count the samples that fall into each bucket
-ul_histogram_counts AS (
-  SELECT
-    date,
-    state,
-    GEOID,
-    bucket_left AS bucket_min,
-    bucket_right AS bucket_max,
-    COUNTIF(upload_MAX BETWEEN bucket_left AND bucket_right) AS bucket_count
-  FROM max_ul_per_day_ip CROSS JOIN buckets
-  GROUP BY
-    date,
-    state,
-    GEOID,
-    bucket_min,
-    bucket_max
-),
-# Turn the counts into frequencies
+ Generate the histogram with samples per bucket and frequencies
 ul_histogram AS (
   SELECT
     date,
-    state,
-    GEOID,
+    continent_code,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) AS ul_samples_bucket,
+    COUNT(*) AS ul_samples_day,
+    COUNTIF(upload_MAX < bucket_right AND upload_MAX >= bucket_left) / COUNT(*) AS ul_frac
+  FROM ul_stats_perip_perday CROSS JOIN buckets
+  GROUP BY
+    date,
+    continent_code,
     bucket_min,
-    bucket_max,
-    bucket_count / samples AS ul_frac,
-    samples AS ul_samples
-  FROM ul_histogram_counts
-  JOIN ul_sample_counts USING (date, state, GEOID)
+    bucket_max
 )
 # Show the results
 SELECT * FROM dl_histogram


### PR DESCRIPTION
@robertodauria identified an issue with our queries that resulted in incorrect sample counts per bucket and overall per day. 

This PR updates all queries currently used in stats-pipeline, with:
* accurate counts of tests per bucket
* adds additional fields ( `dl_total_samples | ul_total_samples | dl_stats_samples | ul_stats_samples` ) to show how many total samples (all tests from all IPs) and the total number of samples used in the daily statistics

In summary:
* `dl_samples_bucket` = the # download tests whose Max mbps measurement was in the bucket range
  * the sum of all `dl_samples_bucket` values for all buckets in a given day aggregation should equal `dl_samples_day`
* `ul_samples_bucket` = the # upload tests whose Max mbps measurement was in the bucket range
  * the sum of all `ul_samples_bucket` values for all buckets in a given day aggregation should equal `ul_samples_day`
* `dl_samples_day` & `dl_stats_samples` = the total # of download tests in a given day used in the statistics aggregation 
* `ul_samples_day`  & `ul_stats_samples` = the total # of upload tests in a given day used in the statistics aggregation
* `dl_frac` =  `dl_samples_bucket` / `dl_samples_day` -- the fraction of download measurements that fell in the bucket range
* `ul_frac` =  `ul_samples_bucket` / `ul_samples_day` -- the fraction of upload measurements that fell in the bucket range
* `dl_total_samples` - the total number of download tests in the initial selection - all tests from each IP
* `ul_total_samples` - the total number of upload tests in the initial selection - all tests from each IP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/16)
<!-- Reviewable:end -->
