### PR TITLE
Add Prometheus metrics to monitor the "export" phase of the pipeline

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -47,7 +47,7 @@ var (
 	})
 
 	cacheHitMetric = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "stats_pipeline_exporter_cache_hit_total",
+		Name: "stats_pipeline_exporter_cache_hits_total",
 		Help: "Number of cache hits",
 	}, []string{
 		"table",
@@ -68,14 +68,14 @@ var (
 	})
 
 	queryProcessedMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_query_processed",
+		Name: "stats_pipeline_exporter_queries_processed",
 		Help: "Queries processed for the current table",
 	}, []string{
 		"table",
 	})
 
 	uploadQueueMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_upload_queue",
+		Name: "stats_pipeline_exporter_uploads_queued",
 		Help: "Number of objects in the upload queue",
 	}, []string{
 		"table",

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -61,7 +61,7 @@ var (
 	})
 
 	queryTotalMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_query_total",
+		Name: "stats_pipeline_exporter_queries_total",
 		Help: "Export queries to be processed for the current table",
 	}, []string{
 		"table",
@@ -82,7 +82,7 @@ var (
 	})
 
 	inFlightUploadsMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_uploads_current",
+		Name: "stats_pipeline_exporter_uploads_inflight",
 		Help: "Number of in-flight uploads",
 	}, []string{
 		"table",
@@ -198,8 +198,8 @@ func (exporter *JSONExporter) Export(ctx context.Context,
 	exporter.queriesDone = 0
 
 	// Reset query number metric.
-	queryTotalMetric.WithLabelValues(config.Table).Set(float64(len(clauses)))
-	queryProcessedMetric.WithLabelValues(config.Table).Set(0)
+	queryTotalMetric.WithLabelValues(sourceTable).Set(float64(len(clauses)))
+	queryProcessedMetric.WithLabelValues(sourceTable).Set(0)
 
 	// Start a goroutine to print statistics periodically.
 	printStatsCtx, cancelPrintStats := context.WithCancel(ctx)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -40,28 +40,28 @@ const (
 var (
 	fieldRegex           = regexp.MustCompile(`{{\s*\.([A-Za-z0-9_]+)\s*}}`)
 	bytesProcessedMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_bytes_processed_total",
+		Name: "stats_pipeline_exporter_bytes_processed",
 		Help: "Bytes processed by the exporter",
 	}, []string{
 		"table",
 	})
 
 	cacheHitMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_cache_hits_total",
+		Name: "stats_pipeline_exporter_cache_hits",
 		Help: "Number of cache hits",
 	}, []string{
 		"table",
 	})
 
 	uploadedBytesMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_uploaded_bytes_total",
+		Name: "stats_pipeline_exporter_uploaded_bytes",
 		Help: "Bytes uploaded to GCS",
 	}, []string{
 		"table",
 	})
 
 	queryTotalMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_queries_total",
+		Name: "stats_pipeline_exporter_queries",
 		Help: "Export queries to be processed for the current table",
 	}, []string{
 		"table",
@@ -202,7 +202,7 @@ func (exporter *JSONExporter) Export(ctx context.Context,
 
 	// The number of queries to run is the same as the number of clauses
 	// generated earlier.
-	queryTotalMetric.WithLabelValues(sourceTable).Set(float64(len(clauses)))
+	queryTotalMetric.WithLabelValues(config.Table).Set(float64(len(clauses)))
 
 	// Start a goroutine to print statistics periodically.
 	printStatsCtx, cancelPrintStats := context.WithCancel(ctx)

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"github.com/m-lab/go/cloudtest/bqfake"
 	"github.com/m-lab/go/cloudtest/gcsfake"
+	"github.com/m-lab/go/prometheusx/promtest"
 	"github.com/m-lab/go/testingx"
 	"google.golang.org/api/iterator"
 )
@@ -383,4 +384,17 @@ func Test_removeFieldsFromRow(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPrometheusMetrics ensures that all the metrics pass the linter.
+func TestPrometheusMetrics(t *testing.T) {
+	bytesProcessedMetric.WithLabelValues("x")
+	cacheHitMetric.WithLabelValues("x")
+	uploadedBytesMetric.WithLabelValues("x")
+	queryTotalMetric.WithLabelValues("x")
+	queryProcessedMetric.WithLabelValues("x")
+	uploadQueueMetric.WithLabelValues("x")
+	inFlightUploadsMetric.WithLabelValues("x")
+
+	promtest.LintMetrics(t)
 }


### PR DESCRIPTION
This PR adds several Prometheus metrics to the exporter package:

- `stats_pipeline_exporter_queries_total`: total number of queries to run to export the current table
- `stats_pipeline_exporter_queries_processed`: number of queries that have been run so far
- `stats_pipeline_exporter_uploads_queued`: number of query workers waiting for a free upload worker
- `stats_pipeline_exporter_uploads_inflight`: number of uploads currently in flight

A preview of how these would look like on Grafana is available at https://grafana.mlab-sandbox.measurementlab.net/d/07rwXefMz/stats-pipeline-monitoring?orgId=1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/39)
<!-- Reviewable:end -->
