### PR TITLE
Replace queue size counter with a histogram.

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -74,19 +74,22 @@ var (
 		"table",
 	})
 
-	uploadQueueMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_exporter_uploads_queued",
-		Help: "Number of objects in the upload queue",
-	}, []string{
-		"table",
-	})
-
 	inFlightUploadsMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "stats_pipeline_exporter_uploads_inflight",
 		Help: "Number of in-flight uploads",
 	}, []string{
 		"table",
 	})
+
+	// Histogram bucket to record the upload queue size.
+	uploadQueueSizeHistogram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "stats_pipeline_exporter_uploads_queue_size",
+			Help:    "Upload queue size histogram",
+			Buckets: []float64{1, 2, 4},
+		},
+		[]string{"table"},
+	)
 )
 
 // Convenience type for a bigquery row.
@@ -372,7 +375,6 @@ func (exporter *JSONExporter) uploadFile(j *QueryJob, rows []bqRow, lastRow bqRo
 		return err
 	}
 	atomic.AddInt32(&exporter.uploadQLen, 1)
-	uploadQueueMetric.WithLabelValues(j.name).Inc()
 	marshalAndUpload(j.name, buf.String(), rows, exporter.uploadJobs)
 	return nil
 }
@@ -387,11 +389,16 @@ func (exporter *JSONExporter) uploadWorker(ctx context.Context,
 	for j := range exporter.uploadJobs {
 		// The uploadQueue counter is decremented before starting to upload
 		// the file, so that in-flight uploads aren't counted.
+		// After this, we observe the size of the upload queue and put its
+		// length in a Prometheus metric.
 		atomic.AddInt32(&exporter.uploadQLen, -1)
-		uploadQueueMetric.WithLabelValues(j.table).Dec()
+		uploadQueueSizeHistogram.WithLabelValues(j.table).Observe(float64(
+			atomic.LoadInt32(&exporter.uploadQLen)))
+
 		inFlightUploadsMetric.WithLabelValues(j.table).Inc()
 		_, err := up.Upload(ctx, j.objName, j.content)
 		inFlightUploadsMetric.WithLabelValues(j.table).Dec()
+
 		uploadedBytesMetric.WithLabelValues(j.table).Add(float64(len(j.content)))
 		exporter.results <- UploadResult{
 			objName: j.objName,
@@ -514,7 +521,6 @@ func removeFieldsFromRow(row bqRow, fields []string) bqRow {
 func resetMetrics(table string) {
 	queryProcessedMetric.WithLabelValues(table).Set(0)
 	inFlightUploadsMetric.WithLabelValues(table).Set(0)
-	uploadQueueMetric.WithLabelValues(table).Set(0)
 	uploadedBytesMetric.WithLabelValues(table).Set(0)
 	bytesProcessedMetric.WithLabelValues(table).Set(0)
 	cacheHitMetric.WithLabelValues(table).Set(0)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -86,7 +86,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "stats_pipeline_exporter_uploads_queue_size",
 			Help:    "Upload queue size histogram",
-			Buckets: []float64{1, 2, 4},
+			Buckets: []float64{0, 1, 2, 4},
 		},
 		[]string{"table"},
 	)

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -393,8 +393,8 @@ func TestPrometheusMetrics(t *testing.T) {
 	uploadedBytesMetric.WithLabelValues("x")
 	queryTotalMetric.WithLabelValues("x")
 	queryProcessedMetric.WithLabelValues("x")
-	uploadQueueMetric.WithLabelValues("x")
 	inFlightUploadsMetric.WithLabelValues("x")
+	uploadQueueSizeHistogram.WithLabelValues("x")
 
 	promtest.LintMetrics(t)
 }


### PR DESCRIPTION
This PR replaces the gauge counting the length of the upload queue with a histogram. Observations of the queue length happen every time we read a job from the channel. This gives us a much more accurate representation of the queue's state over time, where using polling might miss a lot of shorter periods with a lot of queuing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/43)
<!-- Reviewable:end -->
