### PR TITLE
Add "step" parameter to the /pipeline endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+stats-pipeline

--- a/pipeline/handlers_test.go
+++ b/pipeline/handlers_test.go
@@ -74,6 +74,11 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			r:          httptest.NewRequest(http.MethodPost, "/v0/pipeline", nil),
 			statusCode: http.StatusBadRequest,
 		},
+		{
+			name:       "action-histogram",
+			r:          httptest.NewRequest(http.MethodPost, "/v0/pipeline?year=2020&step=histogram", bytes.NewReader([]byte{})),
+			statusCode: http.StatusOK,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pipeline/headers.go
+++ b/pipeline/headers.go
@@ -1,0 +1,6 @@
+package pipeline
+
+const (
+	errMissingYear = "Missing mandatory parameter: year"
+	errMissingStep = "Missing mandatory parameter: step"
+)


### PR DESCRIPTION
This PR lets the caller of the `/v0/pipeline` endpoint select an individual step ("histograms" or "exports") via the `step` querystring parameter. If unspecified, the current behavior of running all of them is retained.

This is useful when testing and in case the export queries are changed, since generating the histogram tables is by far the most expensive step -- and it comes first.

Also, to make this endpoint more testable, it now returns a JSON object in the response body which contains the steps that have been run and any error that occurred.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/44)
<!-- Reviewable:end -->
