### PR TITLE
Add histogram metric to track bytes used in BQ

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,49 +1,9 @@
 {
-    "continents": {
-        "histogramQueryFile": "statistics/queries/continent_histogram.sql",
-        "exportQueryFile": "statistics/exports/continents.sql",
-        "dataset": "statistics",
-        "table": "continents",
-        "outputPath": "v0/{{ .continent_code }}/{{ .year }}/histogram_daily_stats.json"
-    },
     "countries": {
         "histogramQueryFile": "statistics/queries/continent_country_histogram.sql",
         "exportQueryFile": "statistics/exports/countries.sql",
         "dataset": "statistics",
         "table": "countries",
-        "partitionField": "country_code_hash",
         "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .year }}/histogram_daily_stats.json"
-    },
-    "regions": {
-        "histogramQueryFile": "statistics/queries/countinent_country_region_histogram.sql",
-        "exportQueryFile": "statistics/exports/regions.sql",
-        "dataset": "statistics",
-        "table": "regions",
-        "partitionField": "country_code_hash",
-        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .year }}/histogram_daily_stats.json"
-    },
-    "cities": {
-        "histogramQueryFile": "statistics/queries/countinent_country_region_city_histogram.sql",
-        "exportQueryFile": "statistics/exports/cities.sql",
-        "dataset": "statistics",
-        "table": "cities",
-        "partitionField": "region_code_hash",
-        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .city }}/{{ .year }}/histogram_daily_stats.json"
-    },
-    "tracts": {
-        "histogramQueryFile": "statistics/queries/us_census_tracts_histogram.sql",
-        "exportQueryFile": "statistics/exports/us_tracts.sql",
-        "dataset": "statistics",
-        "table": "us_tracts",
-        "partitionField": "tract_hash",
-        "outputPath": "v0/NA/US/tracts/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json"
-    },
-    "counties": {
-        "histogramQueryFile": "statistics/queries/us_county_histogram.sql",
-        "exportQueryFile": "statistics/exports/us_counties.sql",
-        "dataset": "statistics",
-        "table": "us_counties",
-        "partitionField": "county_hash",
-        "outputPath": "v0/NA/US/counties/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json"
     }
 }

--- a/config.json
+++ b/config.json
@@ -1,9 +1,44 @@
 {
+    "continents": {
+        "histogramQueryFile": "statistics/queries/continent_histogram.sql",
+        "exportQueryFile": "statistics/exports/continents.sql",
+        "dataset": "statistics",
+        "table": "continents",
+        "outputPath": "v0/{{ .continent_code }}/{{ .year }}/histogram_daily_stats.json"
+    },
     "countries": {
         "histogramQueryFile": "statistics/queries/continent_country_histogram.sql",
         "exportQueryFile": "statistics/exports/countries.sql",
         "dataset": "statistics",
         "table": "countries",
         "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .year }}/histogram_daily_stats.json"
+    },
+    "regions": {
+        "histogramQueryFile": "statistics/queries/continent_country_region_histogram.sql",
+        "exportQueryFile": "statistics/exports/regions.sql",
+        "dataset": "statistics",
+        "table": "regions",
+        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .year }}/histogram_daily_stats.json"
+    },
+    "cities": {
+        "histogramQueryFile": "statistics/queries/continent_country_region_city_histogram.sql",
+        "exportQueryFile": "statistics/exports/cities.sql",
+        "dataset": "statistics",
+        "table": "cities",
+        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .city }}/{{ .year }}/histogram_daily_stats.json"
+    },
+    "tracts": {
+        "histogramQueryFile": "statistics/queries/us_census_tracts_histogram.sql",
+        "exportQueryFile": "statistics/exports/us_tracts.sql",
+        "dataset": "statistics",
+        "table": "us_tracts",
+        "outputPath": "v0/NA/US/tracts/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json"
+    },
+    "counties": {
+        "histogramQueryFile": "statistics/queries/us_county_histogram.sql",
+        "exportQueryFile": "statistics/exports/us_counties.sql",
+        "dataset": "statistics",
+        "table": "us_counties",
+        "outputPath": "v0/NA/US/counties/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json"
     }
 }

--- a/histogram/table.go
+++ b/histogram/table.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	queryBytesProcessMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "stats_pipeline_histogram_query_bytes",
+		Name: "stats_pipeline_histograms_bytes_processed",
 		Help: "Bytes processed by the histogram query",
 	}, []string{
 		"table",

--- a/histogram/table.go
+++ b/histogram/table.go
@@ -118,10 +118,6 @@ func (t *Table) UpdateHistogram(ctx context.Context, start, end time.Time) error
 	query := t.client.Query(t.query)
 	query.SetQueryConfig(qc)
 
-	// Reset bytes process Prometheus gauge for this query.
-	queryBytesProcessMetric.
-		WithLabelValues(t.Table.FullyQualifiedName()).Set(0)
-
 	// Run the histogram generation query.
 	log.Printf("Generating histogram data for table %s\n", t.TableID())
 	bqJob, err := query.Run(ctx)

--- a/histogram/table_test.go
+++ b/histogram/table_test.go
@@ -9,6 +9,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
+	"github.com/m-lab/go/prometheusx/promtest"
 	"github.com/m-lab/go/rtx"
 )
 
@@ -208,4 +209,10 @@ func TestTable_UpdateHistogram(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrometheusMetrics(t *testing.T) {
+	queryBytesProcessMetric.WithLabelValues("x")
+
+	promtest.LintMetrics(t)
 }


### PR DESCRIPTION
This PR adds `stats_pipeline_histogram_bytes_processed` to track how many bytes are used by each histogram generation query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/48)
<!-- Reviewable:end -->
