### PR TITLE
Remove partitioning field when exporting data to JSON

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -500,9 +500,11 @@ func getFieldsFromPath(path string) ([]string, error) {
 	return fields, nil
 }
 
-// removeFieldsFromRow returns a new BQ row without the specified fields.
+// removeFieldsFromRow returns a new BQ row without the specified fields. It
+// also removes the partitioning field if present.
 func removeFieldsFromRow(row bqRow, fields []string) bqRow {
 	newRow := bqRow{}
+	fields = append(fields, partitionField)
 	for fieldName, fieldValue := range row {
 		found := false
 		for _, k := range fields {


### PR DESCRIPTION
This change makes sure the partitioning field doesn't appear in the final JSON but always including it in the fields to filter out in `removeFieldsFromRow`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/50)
<!-- Reviewable:end -->
