### PR TITLE
Update queries using "region" fields

### DIFF
--- a/statistics/queries/continent_country_region_asn_histogram.sql
+++ b/statistics/queries/continent_country_region_asn_histogram.sql
@@ -11,8 +11,11 @@ dl_per_location_cleaned AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode, '-', client.Geo.Subdivision1ISOCode) AS 
-    ISO3166_2region1,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS ISO3166_2region1,
     client.Network.ASNumber AS asn,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
     id,
@@ -107,8 +110,11 @@ ul_per_location_cleaned AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode, '-', client.Geo.Subdivision1ISOCode) AS
-    ISO3166_2region1,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS ISO3166_2region1,
     client.Network.ASNumber AS asn,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
     id,

--- a/statistics/queries/continent_country_region_asn_histogram.sql
+++ b/statistics/queries/continent_country_region_asn_histogram.sql
@@ -26,7 +26,8 @@ dl_per_location_cleaned AS (
   AND a.MeanThroughputMbps != 0
   AND client.Geo.ContinentCode IS NOT NULL AND client.Geo.ContinentCode != ""
   AND client.Geo.CountryCode IS NOT NULL AND client.Geo.CountryCode != ""
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND client.Network.ASNumber IS NOT NULL
   AND Client.IP IS NOT NULL
 ),
@@ -125,7 +126,8 @@ ul_per_location_cleaned AS (
   AND a.MeanThroughputMbps != 0
   AND client.Geo.ContinentCode IS NOT NULL AND client.Geo.ContinentCode != ""
   AND client.Geo.CountryCode IS NOT NULL AND client.Geo.CountryCode != ""
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND client.Network.ASNumber IS NOT NULL
   AND Client.IP IS NOT NULL
 ),

--- a/statistics/queries/continent_country_region_city_asn_histogram.sql
+++ b/statistics/queries/continent_country_region_city_asn_histogram.sql
@@ -27,7 +27,8 @@ dl_per_location_cleaned AS (
   AND a.MeanThroughputMbps != 0
   AND client.Geo.ContinentCode IS NOT NULL AND client.Geo.ContinentCode != ""
   AND client.Geo.CountryCode IS NOT NULL AND client.Geo.CountryCode != ""
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND client.Geo.City IS NOT NULL AND client.Geo.City != ""
   AND client.Network.ASNumber IS NOT NULL
   AND Client.IP IS NOT NULL
@@ -132,7 +133,8 @@ ul_per_location_cleaned AS (
   AND a.MeanThroughputMbps != 0
   AND client.Geo.ContinentCode IS NOT NULL AND client.Geo.ContinentCode != ""
   AND client.Geo.CountryCode IS NOT NULL AND client.Geo.CountryCode != ""
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND client.Geo.City IS NOT NULL AND client.Geo.City != ""
   AND client.Network.ASNumber IS NOT NULL
   AND Client.IP IS NOT NULL

--- a/statistics/queries/continent_country_region_city_asn_histogram.sql
+++ b/statistics/queries/continent_country_region_city_asn_histogram.sql
@@ -11,7 +11,11 @@ dl_per_location_cleaned AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode, '-', client.Geo.Subdivision1ISOCode) AS ISO3166_2region1,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS ISO3166_2region1,
     client.Geo.City AS city,
     client.Network.ASNumber AS asn,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
@@ -112,8 +116,11 @@ ul_per_location_cleaned AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode, '-', client.Geo.Subdivision1ISOCode) AS
-    ISO3166_2region1,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS ISO3166_2region1,
     client.Geo.City AS city,
     client.Network.ASNumber AS asn,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,

--- a/statistics/queries/continent_country_region_city_histogram.sql
+++ b/statistics/queries/continent_country_region_city_histogram.sql
@@ -11,7 +11,11 @@ dl_per_location_cleaned AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode, '-', client.Geo.Subdivision1ISOCode) AS ISO3166_2region1,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS ISO3166_2region1,
     client.Geo.City AS city,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
     id,
@@ -106,8 +110,11 @@ ul_per_location_cleaned AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode, '-', client.Geo.Subdivision1ISOCode) AS
-    ISO3166_2region1,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS ISO3166_2region1,
     client.Geo.City AS city,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
     id,

--- a/statistics/queries/continent_country_region_city_histogram.sql
+++ b/statistics/queries/continent_country_region_city_histogram.sql
@@ -26,7 +26,8 @@ dl_per_location_cleaned AS (
   AND a.MeanThroughputMbps != 0
   AND client.Geo.ContinentCode IS NOT NULL AND client.Geo.ContinentCode != ""
   AND client.Geo.CountryCode IS NOT NULL AND client.Geo.CountryCode != ""
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND client.Geo.City IS NOT NULL AND client.Geo.City != ""
   AND Client.IP IS NOT NULL
 ),
@@ -125,7 +126,8 @@ ul_per_location_cleaned AS (
   AND a.MeanThroughputMbps != 0
   AND client.Geo.ContinentCode IS NOT NULL AND client.Geo.ContinentCode != ""
   AND client.Geo.CountryCode IS NOT NULL AND client.Geo.CountryCode != ""
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND client.Geo.City IS NOT NULL AND client.Geo.City != ""
   AND Client.IP IS NOT NULL
 ),

--- a/statistics/queries/continent_country_region_histogram.sql
+++ b/statistics/queries/continent_country_region_histogram.sql
@@ -11,7 +11,11 @@ dl_per_location_cleaned AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode, '-', client.Geo.Subdivision1ISOCode) AS ISO3166_2region1,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS ISO3166_2region1,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
     id,
     a.MeanThroughputMbps AS mbps,
@@ -100,8 +104,11 @@ ul_per_location_cleaned AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode, '-', client.Geo.Subdivision1ISOCode) AS
-    ISO3166_2region1,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS ISO3166_2region1,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
     id,
     a.MeanThroughputMbps AS mbps,

--- a/statistics/queries/continent_country_region_histogram.sql
+++ b/statistics/queries/continent_country_region_histogram.sql
@@ -25,7 +25,8 @@ dl_per_location_cleaned AS (
   AND a.MeanThroughputMbps != 0
   AND client.Geo.ContinentCode IS NOT NULL AND client.Geo.ContinentCode != ""
   AND client.Geo.CountryCode IS NOT NULL AND client.Geo.CountryCode != ""
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND Client.IP IS NOT NULL
 ),
 --Fingerprint all cleaned tests, in an arbitrary but repeatable order
@@ -118,7 +119,8 @@ ul_per_location_cleaned AS (
   AND a.MeanThroughputMbps != 0
   AND client.Geo.ContinentCode IS NOT NULL AND client.Geo.ContinentCode != ""
   AND client.Geo.CountryCode IS NOT NULL AND client.Geo.CountryCode != ""
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND Client.IP IS NOT NULL
 ),
 --Fingerprint all cleaned tests, in an arbitrary but repeatable order.

--- a/statistics/queries/us_census_tracts_asn_histogram.sql
+++ b/statistics/queries/us_census_tracts_asn_histogram.sql
@@ -36,7 +36,11 @@ dl_per_location AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) AS state,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS state,
     tracts.GEOID AS GEOID,
     tracts.state_name AS state_name,
     tracts.tract_name AS tract_name,
@@ -170,7 +174,11 @@ ul_per_location AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) AS state,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS state, 
     tracts.GEOID AS GEOID,
     client.Network.ASNumber AS asn,
     tracts.state_name AS state_name,

--- a/statistics/queries/us_census_tracts_asn_histogram.sql
+++ b/statistics/queries/us_census_tracts_asn_histogram.sql
@@ -53,8 +53,8 @@ dl_per_location AS (
   FROM `measurement-lab.ndt.unified_downloads`, tracts
   WHERE date BETWEEN @startdate AND @enddate
   AND client.Geo.CountryCode = "US"
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL
-  AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
     AND ST_WITHIN(
       ST_GeogPoint(
         client.Geo.Longitude,
@@ -191,8 +191,8 @@ ul_per_location AS (
   FROM `measurement-lab.ndt.unified_uploads`, tracts
   WHERE date BETWEEN @startdate AND @enddate
   AND client.Geo.CountryCode = "US"
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL
-  AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
     AND ST_WITHIN(
       ST_GeogPoint(
         client.Geo.Longitude,

--- a/statistics/queries/us_census_tracts_histogram.sql
+++ b/statistics/queries/us_census_tracts_histogram.sql
@@ -52,8 +52,8 @@ dl_per_location AS (
   FROM `measurement-lab.ndt.unified_downloads`, tracts
   WHERE date BETWEEN @startdate AND @enddate
   AND client.Geo.CountryCode = "US"
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL
-  AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
     AND ST_WITHIN(
       ST_GeogPoint(
         client.Geo.Longitude,
@@ -184,8 +184,8 @@ ul_per_location AS (
   FROM `measurement-lab.ndt.unified_uploads`, tracts
   WHERE date BETWEEN @startdate AND @enddate
   AND client.Geo.CountryCode = "US"
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL
-  AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
     AND ST_WITHIN(
       ST_GeogPoint(
         client.Geo.Longitude,

--- a/statistics/queries/us_census_tracts_histogram.sql
+++ b/statistics/queries/us_census_tracts_histogram.sql
@@ -36,7 +36,11 @@ dl_per_location AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) AS state,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS state,
     tracts.GEOID AS GEOID,
     tracts.state_name AS state_name,
     tracts.tract_name AS tract_name,
@@ -164,7 +168,11 @@ ul_per_location AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) AS state,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS state,
     tracts.GEOID AS GEOID,
     tracts.state_name AS state_name,
     tracts.tract_name AS tract_name,

--- a/statistics/queries/us_county_asn_histogram.sql
+++ b/statistics/queries/us_county_asn_histogram.sql
@@ -30,7 +30,11 @@ dl_per_location AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) AS state,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS state,
     client.Network.ASNumber AS asn,
     counties.GEOID AS GEOID,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
@@ -144,7 +148,11 @@ ul_per_location AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) AS state,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode)
+    END AS state,
     counties.GEOID AS GEOID,
     client.Network.ASNumber AS asn,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,

--- a/statistics/queries/us_county_asn_histogram.sql
+++ b/statistics/queries/us_county_asn_histogram.sql
@@ -44,8 +44,8 @@ dl_per_location AS (
   FROM `measurement-lab.ndt.unified_downloads`, counties
   WHERE date BETWEEN @startdate AND @enddate
   AND client.Geo.CountryCode = "US"
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL
-  AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND client.Network.ASNumber IS NOT NULL
   AND ST_WITHIN(
     ST_GeogPoint(
@@ -161,8 +161,8 @@ ul_per_location AS (
     a.MinRTT AS MinRTT
   FROM `measurement-lab.ndt.unified_uploads`, counties
   WHERE date BETWEEN @startdate AND @enddate
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL
-  AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND client.Network.ASNumber IS NOT NULL
   AND ST_WITHIN(
     ST_GeogPoint(

--- a/statistics/queries/us_county_histogram.sql
+++ b/statistics/queries/us_county_histogram.sql
@@ -30,7 +30,10 @@ dl_per_location AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) AS state,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) END AS state,
     counties.GEOID AS GEOID,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
     id,
@@ -39,8 +42,8 @@ dl_per_location AS (
   FROM `measurement-lab.ndt.unified_downloads`, counties
   WHERE date BETWEEN @startdate AND @enddate
   AND client.Geo.CountryCode = "US"
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL
-  AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND ST_WITHIN(
     ST_GeogPoint(
       client.Geo.Longitude,
@@ -138,7 +141,10 @@ ul_per_location AS (
     date,
     client.Geo.ContinentCode AS continent_code,
     client.Geo.CountryCode AS country_code,
-    CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) AS state,
+    CASE WHEN node._instruments IN ("tcpinfo", "web100") 
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.region)
+    WHEN node._instruments = "ndt7"
+      THEN CONCAT(client.Geo.CountryCode,"-",client.Geo.Subdivision1ISOCode) END AS state,
     counties.GEOID AS GEOID,
     NET.SAFE_IP_FROM_STRING(Client.IP) AS ip,
     id,
@@ -146,8 +152,8 @@ ul_per_location AS (
     a.MinRTT AS MinRTT
   FROM `measurement-lab.ndt.unified_uploads`, counties
   WHERE date BETWEEN @startdate AND @enddate
-  AND client.Geo.Subdivision1ISOCode IS NOT NULL
-  AND client.Geo.Subdivision1ISOCode != ""
+  AND (client.Geo.Subdivision1ISOCode IS NOT NULL OR client.Geo.Region IS NOT NULL)
+  AND (client.Geo.Subdivision1ISOCode != "" OR client.Geo.Region != "")
   AND ST_WITHIN(
     ST_GeogPoint(
       client.Geo.Longitude,


### PR DESCRIPTION
This PR updates all queries that have annotations in `client.Geo.Region` or `client.Geo.Subdivision1ISOCode`, depending on the annotator used. For reference, there are three time periods of interest related to different annotation services and source data, which are currently being unified:
| **Geo Annotations** | Dates in use | **TCP Statistics Source** | Dates in use |
|:-------------------:|:------------:|:-------------------------:|:------------:|
| geo1, annotation-service | 2009-01 - 2017-08 | web100 | 2009-01 - 2019-11 |   |
| geo2, annotation-service | 2017-09 - 2020-02 | tcpinfo | 2019-11 - present | 
| geo2, uuid-annotator     | 2020-03 - present |  |  |

This PR has been tested with data back to 2018-01-01, so should be suitable to use for generating statistics for 2018 to present, while work is ongoing to re-annotate geo1 annotated data and data types still using the annotation-service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/53)
<!-- Reviewable:end -->
