### PR TITLE
Remove fields filtering from JSON output

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -354,7 +354,7 @@ func (exporter *JSONExporter) processQueryResults(it bqiface.RowIterator,
 		// We are in the middle or start of a file, so just append the current
 		// row to currentFile. The partitionField is removed from the output.
 		currentFile = append(currentFile, removeFieldsFromRow(currentRow,
-			[]string{partitionField}))
+			[]string{}))
 		// Save relevant fields for comparison in the next iteration.
 		// Note: we can't just do lastRow = currentRow here as it would be a
 		// reference; we need to copy.

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -354,7 +354,7 @@ func (exporter *JSONExporter) processQueryResults(it bqiface.RowIterator,
 		// We are in the middle or start of a file, so just append the current
 		// row to currentFile. Fields that appear in the output path are
 		// removed to avoid redundancy in the JSON and create smaller files.
-		currentFile = append(currentFile, removeFieldsFromRow(currentRow, j.fields))
+		currentFile = append(currentFile, currentRow)
 		// Save relevant fields for comparison in the next iteration.
 		// Note: we can't just do lastRow = currentRow here as it would be a
 		// reference; we need to copy.
@@ -515,25 +515,6 @@ func getFieldsFromPath(path string) ([]string, error) {
 		fields = append(fields, m[1])
 	}
 	return fields, nil
-}
-
-// removeFieldsFromRow returns a new BQ row without the specified fields. It
-// also removes the partitioning field if present.
-func removeFieldsFromRow(row bqRow, fields []string) bqRow {
-	newRow := bqRow{}
-	fields = append(fields, partitionField)
-	for fieldName, fieldValue := range row {
-		found := false
-		for _, k := range fields {
-			if fieldName == k {
-				found = true
-			}
-		}
-		if !found {
-			newRow[fieldName] = fieldValue
-		}
-	}
-	return newRow
 }
 
 // resetMetrics sets all the metrics for a given table to zero.

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -351,41 +351,6 @@ func Test_getFieldsFromPath(t *testing.T) {
 	}
 }
 
-func Test_removeFieldsFromRow(t *testing.T) {
-	fakeRow := bqRow{
-		"test":   "foo",
-		"remove": "this",
-	}
-	tests := []struct {
-		name   string
-		row    bqRow
-		fields []string
-		want   bqRow
-	}{
-		{
-			name:   "ok-field-removed",
-			row:    fakeRow,
-			fields: []string{"remove"},
-			want: bqRow{
-				"test": "foo",
-			},
-		},
-		{
-			name:   "not-found-return-original-row",
-			row:    fakeRow,
-			fields: []string{"non-existing-field"},
-			want:   fakeRow,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := removeFieldsFromRow(tt.row, tt.fields); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("removeFieldsFromRow() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // TestPrometheusMetrics ensures that all the metrics pass the linter.
 func TestPrometheusMetrics(t *testing.T) {
 	bytesProcessedMetric.WithLabelValues("x")

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -351,6 +351,41 @@ func Test_getFieldsFromPath(t *testing.T) {
 	}
 }
 
+func Test_removeFieldsFromRow(t *testing.T) {
+	fakeRow := bqRow{
+		"test":   "foo",
+		"remove": "this",
+	}
+	tests := []struct {
+		name   string
+		row    bqRow
+		fields []string
+		want   bqRow
+	}{
+		{
+			name:   "ok-field-removed",
+			row:    fakeRow,
+			fields: []string{"remove"},
+			want: bqRow{
+				"test": "foo",
+			},
+		},
+		{
+			name:   "not-found-return-original-row",
+			row:    fakeRow,
+			fields: []string{"non-existing-field"},
+			want:   fakeRow,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeFieldsFromRow(tt.row, tt.fields); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeFieldsFromRow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestPrometheusMetrics ensures that all the metrics pass the linter.
 func TestPrometheusMetrics(t *testing.T) {
 	bytesProcessedMetric.WithLabelValues("x")

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -115,10 +115,6 @@ type mockRowIterator struct {
 	index   int
 }
 
-func (it *mockRowIterator) PageInfo() *iterator.PageInfo {
-	return &iterator.PageInfo{}
-}
-
 func (it *mockRowIterator) Next(dst interface{}) error {
 	// Check config for an error.
 	if it.iterErr != nil {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -115,6 +115,10 @@ type mockRowIterator struct {
 	index   int
 }
 
+func (it *mockRowIterator) PageInfo() *iterator.PageInfo {
+	return &iterator.PageInfo{}
+}
+
 func (it *mockRowIterator) Next(dst interface{}) error {
 	// Check config for an error.
 	if it.iterErr != nil {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -337,7 +337,7 @@ func TestJSONExporter_processQueryResults(t *testing.T) {
 	}
 
 	if len(rows) == 0 {
-		t.Errorf("Output JSON is empty")
+		t.Fatal("Output JSON is empty")
 	}
 	row := rows[0]
 	if _, ok := row["shard"]; ok {

--- a/exporter/testdata/export_query.sql
+++ b/exporter/testdata/export_query.sql
@@ -1,0 +1,2 @@
+SELECT * FROM {{ .sourceTable }}
+WHERE {{ .whereClause }}

--- a/exporter/testdata/histogram_query.sql
+++ b/exporter/testdata/histogram_query.sql
@@ -1,0 +1,1 @@
+// Note: this is not used by unit tests in the exporter package.

--- a/exporter/testdata/histogram_query.sql
+++ b/exporter/testdata/histogram_query.sql
@@ -1,1 +1,0 @@
-// Note: this is not used by unit tests in the exporter package.


### PR DESCRIPTION
This PR removes the fields filtering from the stats-pipeline JSON output so that fields that already appear in the output path are also repeated in the file's content -- e.g. "asn", "year", "GEOID", ...

The partitioning field ("shard") is still removed as it has no utility for the end user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/62)
<!-- Reviewable:end -->
