### PR TITLE
Add output support option for GCSWriter or LocalWriter

### DIFF
--- a/cmd/stats-pipeline/main.go
+++ b/cmd/stats-pipeline/main.go
@@ -46,6 +46,7 @@ func init() {
 	flag.StringVar(&bucket, "bucket", "statistics-mlab-sandbox",
 		"GCS bucket to export the result to")
 	flag.Var(&configFile, "config", "JSON configuration file")
+	flag.Var(&outputType, "output", "Output to gcs or local files.")
 }
 
 func makeHTTPServer(listenAddr string, h http.Handler) *http.Server {

--- a/cmd/stats-pipeline/main.go
+++ b/cmd/stats-pipeline/main.go
@@ -8,12 +8,11 @@ import (
 	"net/http"
 	"runtime"
 
-	"github.com/m-lab/stats-pipeline/output"
-
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/storage"
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/httpx"
 	"github.com/m-lab/go/prometheusx"
@@ -21,6 +20,7 @@ import (
 	"github.com/m-lab/go/uploader"
 	"github.com/m-lab/stats-pipeline/config"
 	"github.com/m-lab/stats-pipeline/exporter"
+	"github.com/m-lab/stats-pipeline/output"
 	"github.com/m-lab/stats-pipeline/pipeline"
 )
 

--- a/output/writer.go
+++ b/output/writer.go
@@ -1,0 +1,47 @@
+package output
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/m-lab/go/uploader"
+)
+
+// GCSWriter provides Write operations to a GCS bucket.
+type GCSWriter struct {
+	up *uploader.Uploader
+}
+
+// NewGCSWriter creates a new GCSWriter from the given uploader.Uploader.
+func NewGCSWriter(up *uploader.Uploader) *GCSWriter {
+	return &GCSWriter{up: up}
+}
+
+// Write creates a new object at path containing content.
+func (u *GCSWriter) Write(ctx context.Context, path string, content []byte) error {
+	_, err := u.up.Upload(ctx, path, content)
+	return err
+}
+
+// LocalWriter provides Write operations to a local directory.
+type LocalWriter struct {
+	dir string
+}
+
+// NewLocalWriter creates a new LocalWriter for the given output directory.
+func NewLocalWriter(dir string) *LocalWriter {
+	return &LocalWriter{dir: dir}
+}
+
+// Write creates a new file at path containing content.
+func (lu *LocalWriter) Write(ctx context.Context, path string, content []byte) error {
+	p := filepath.Join(lu.dir, path)
+	d := filepath.Dir(p) // path may include additional directory elements.
+	err := os.MkdirAll(d, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(p, content, 0664)
+}

--- a/output/writer_test.go
+++ b/output/writer_test.go
@@ -1,0 +1,82 @@
+package output
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/m-lab/go/cloudtest/gcsfake"
+	"github.com/m-lab/go/testingx"
+	"github.com/m-lab/go/uploader"
+)
+
+func TestGCSWriter_Write(t *testing.T) {
+	failingBucket := gcsfake.NewBucketHandle()
+	failingBucket.WritesMustFail = true
+
+	client := &gcsfake.GCSClient{}
+	client.AddTestBucket("test_bucket", gcsfake.NewBucketHandle())
+	client.AddTestBucket("failing_bucket", failingBucket)
+
+	tests := []struct {
+		name    string
+		path    string
+		content []byte
+		wantErr bool
+	}{
+		{
+			name:    "success-write",
+			path:    "output/name",
+			content: []byte{0, 1, 2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := NewGCSWriter(uploader.New(client, "test_bucket"))
+			if err := u.Write(context.Background(), tt.path, tt.content); (err != nil) != tt.wantErr {
+				t.Errorf("GCSWriter.Write() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLocalWriter_Write(t *testing.T) {
+	tests := []struct {
+		name    string
+		dir     string
+		path    string
+		content []byte
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			dir:     t.TempDir(),
+			path:    "output/name",
+			content: []byte{0, 1, 2},
+		},
+		{
+			name:    "error",
+			dir:     t.TempDir(),
+			path:    "file.not-a-dir/name",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr {
+				p := filepath.Join(tt.dir, tt.path)
+				err := os.MkdirAll(filepath.Dir(filepath.Dir(p)), os.ModePerm)
+				testingx.Must(t, err, "failed to mkdir")
+				// create a file where a directory should be.
+				f, err := os.Create(filepath.Dir(p))
+				testingx.Must(t, err, "failed to create file")
+				f.Close()
+			}
+			lu := NewLocalWriter(tt.dir)
+			if err := lu.Write(context.Background(), tt.path, tt.content); (err != nil) != tt.wantErr {
+				t.Errorf("LocalWriter.Write() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a new local output option in addition to GCS output.

This change adds a new `Enum` flag named `-output` with two options. The default value remains `gcs`. The new output option for `local` uses the `-bucket` flag as an output directory, and writes results to local files.

This change is to support the synthetic annotation export process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/65)
<!-- Reviewable:end -->
