### PR TITLE
Make partitioning configurable during the query phase

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,32 +3,37 @@ package config
 // Config is a configuration object for the stats pipeline.
 type Config struct {
 	// HistogramQueryFile is the path to the query generating the histogram table.
+	// This field is required.
 	HistogramQueryFile string
 
 	// DateField is the name of the date field in the query.
 	// This is used to determine which rows to delete from the histogram table
-	// when updating a certain range of dates.
+	// when updating a certain range of dates. This field is required.
 	DateField string
 
 	// PartitionField is the field used to partition the histogram table.
 	// It may be the same as DateField or a different field.
+	// This field is optional.
 	PartitionField string
 
 	// PartitionType is the type of partitioning used.
 	// Possible values are:
 	//   - "time": partition by timestamp, date or datetime
 	//   - "range": partition by integer range
+	// This field is optional.
 	PartitionType string
 
 	// ExportQueryFile is the path to the export query.
+	// This field is required.
 	ExportQueryFile string
 
-	// Dataset is the dataset name.
+	// Dataset is the dataset name. This field is required.
 	Dataset string
 
-	// Table is the histogram table name.
+	// Table is the histogram table name. This field is required.
 	Table string
 
-	// OutputPath is a template defining the output path on GCS.
+	// OutputPath is a template defining the output path - either local or GCS.
+	// This field is required.
 	OutputPath string
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,12 +4,31 @@ package config
 type Config struct {
 	// HistogramQueryFile is the path to the query generating the histogram table.
 	HistogramQueryFile string
+
+	// DateField is the name of the date field in the query.
+	// This is used to determine which rows to delete from the histogram table
+	// when updating a certain range of dates.
+	DateField string
+
+	// PartitionField is the field used to partition the histogram table.
+	// It may be the same as DateField or a different field.
+	PartitionField string
+
+	// PartitionType is the type of partitioning used.
+	// Possible values are:
+	//   - "time": partition by timestamp, date or datetime
+	//   - "range": partition by integer range
+	PartitionType string
+
 	// ExportQueryFile is the path to the export query.
 	ExportQueryFile string
+
 	// Dataset is the dataset name.
 	Dataset string
+
 	// Table is the histogram table name.
 	Table string
+
 	// OutputPath is a template defining the output path on GCS.
 	OutputPath string
 }

--- a/histogram/table.go
+++ b/histogram/table.go
@@ -25,30 +25,52 @@ var (
 )
 
 const (
-	dateFormat     = "2006-01-02"
-	deleteRowsTpl  = "DELETE FROM {{.Table}} WHERE date BETWEEN \"{{.Start}}\" AND \"{{.End}}\""
-	partitionField = "shard"
+	dateFormat    = "2006-01-02"
+	deleteRowsTpl = "DELETE FROM {{.Table}} WHERE {{.DateField}} BETWEEN \"{{.Start}}\" AND \"{{.End}}\""
 )
+
+const (
+	// TimePartitioning represents date-based partitioning.
+	TimePartitioning = "date"
+
+	// RangePartitioning represents range-based partitioning.
+	RangePartitioning = "range"
+)
+
+type QueryConfig struct {
+	// Query is the SQL Query to run.
+	Query string
+
+	// DateField is the field to use to determine which rows must be deleted
+	// on a table update. It can be the same as partitionField, or different.
+	DateField string
+
+	// PartitionField is the field to use for date or range partitioning.
+	PartitionField string
+
+	// PartitionType is the type of partitioning to use (date or range).
+	PartitionType string
+}
 
 // Table represents a bigquery table containing histogram data.
 // It embeds bigquery.Table and extends it with an UpdateHistogram method.
 type Table struct {
 	bqiface.Table
 
-	// query is the generating query for this Table
-	query string
+	// config is the configuration for the query generating this table.
+	config QueryConfig
 
-	// client is the BigQuery client to use.
+	// client is the bigquery client used to execute the query.
 	client bqiface.Client
 }
 
 // NewTable returns a new Table with the specified destination table, query
 // and BQ client.
-func NewTable(name string, ds string, query string,
+func NewTable(name string, ds string, config QueryConfig,
 	client bqiface.Client) *Table {
 	return &Table{
 		Table:  client.Dataset(ds).Table(name),
-		query:  query,
+		config: config,
 		client: client,
 	}
 }
@@ -59,14 +81,15 @@ func (t *Table) queryConfig(query string) bqiface.QueryConfig {
 	return qc
 }
 
-// deleteRows removes rows where date is within the provided range.
+// deleteRows removes rows where dateField is within the provided range.
 func (t *Table) deleteRows(ctx context.Context, start, end time.Time) error {
 	tpl := template.Must(template.New("query").Parse(deleteRowsTpl))
 	q := &bytes.Buffer{}
 	err := tpl.Execute(q, map[string]string{
-		"Table": t.DatasetID() + "." + t.TableID(),
-		"Start": start.Format(dateFormat),
-		"End":   end.Format(dateFormat),
+		"Table":     t.DatasetID() + "." + t.TableID(),
+		"DateField": t.config.DateField,
+		"Start":     start.Format(dateFormat),
+		"End":       end.Format(dateFormat),
 	})
 	if err != nil {
 		return err
@@ -100,14 +123,21 @@ func (t *Table) UpdateHistogram(ctx context.Context, start, end time.Time) error
 	}
 
 	// Configure the histogram generation query.
-	qc := t.queryConfig(t.query)
-	qc.RangePartitioning = &bigquery.RangePartitioning{
-		Field: partitionField,
-		Range: &bigquery.RangePartitioningRange{
-			Start:    0,
-			End:      3999,
-			Interval: 1,
-		},
+	qc := t.queryConfig(t.config.Query)
+	switch t.config.PartitionField {
+	case RangePartitioning:
+		qc.RangePartitioning = &bigquery.RangePartitioning{
+			Field: t.config.PartitionField,
+			Range: &bigquery.RangePartitioningRange{
+				Start:    0,
+				End:      3999,
+				Interval: 1,
+			},
+		}
+	case TimePartitioning:
+		qc.TimePartitioning = &bigquery.TimePartitioning{
+			Field: t.config.PartitionField,
+		}
 	}
 
 	qc.Dst = t.Table
@@ -122,7 +152,7 @@ func (t *Table) UpdateHistogram(ctx context.Context, start, end time.Time) error
 			Value: end.Format(dateFormat),
 		},
 	}
-	query := t.client.Query(t.query)
+	query := t.client.Query(t.config.Query)
 	query.SetQueryConfig(qc)
 
 	// Run the histogram generation query.

--- a/k8s/data-processing/config/config.json
+++ b/k8s/data-processing/config/config.json
@@ -4,104 +4,149 @@
         "exportQueryFile": "statistics/exports/continents.sql",
         "dataset": "statistics",
         "table": "continents",
-        "outputPath": "v0/{{ .continent_code }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/{{ .continent_code }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "countries": {
         "histogramQueryFile": "statistics/queries/continent_country_histogram.sql",
         "exportQueryFile": "statistics/exports/countries.sql",
         "dataset": "statistics",
         "table": "countries",
-        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "regions": {
         "histogramQueryFile": "statistics/queries/continent_country_region_histogram.sql",
         "exportQueryFile": "statistics/exports/regions.sql",
         "dataset": "statistics",
         "table": "regions",
-        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "cities": {
         "histogramQueryFile": "statistics/queries/continent_country_region_city_histogram.sql",
         "exportQueryFile": "statistics/exports/cities.sql",
         "dataset": "statistics",
         "table": "cities",
-        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .city }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .city }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "tracts": {
         "histogramQueryFile": "statistics/queries/us_census_tracts_histogram.sql",
         "exportQueryFile": "statistics/exports/us_tracts.sql",
         "dataset": "statistics",
         "table": "us_tracts",
-        "outputPath": "v0/NA/US/tracts/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/NA/US/tracts/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "states": {
         "histogramQueryFile": "statistics/queries/us_state_territories_histogram.sql",
         "exportQueryFile": "statistics/exports/us_states.sql",
         "dataset": "statistics",
         "table": "us_states",
-        "outputPath": "v0/NA/US/states/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/NA/US/states/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "counties": {
         "histogramQueryFile": "statistics/queries/us_county_histogram.sql",
         "exportQueryFile": "statistics/exports/us_counties.sql",
         "dataset": "statistics",
         "table": "us_counties",
-        "outputPath": "v0/NA/US/counties/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/NA/US/counties/{{ .GEOID }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "continents_asn": {
         "histogramQueryFile": "statistics/queries/continent_asn_histogram.sql",
         "exportQueryFile": "statistics/exports/continents_asn.sql",
         "dataset": "statistics",
         "table": "continents_asn",
-        "outputPath": "v0/{{ .continent_code }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/{{ .continent_code }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "countries_asn": {
         "histogramQueryFile": "statistics/queries/continent_country_asn_histogram.sql",
         "exportQueryFile": "statistics/exports/countries_asn.sql",
         "dataset": "statistics",
         "table": "countries_asn",
-        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "regions_asn": {
         "histogramQueryFile": "statistics/queries/continent_country_region_asn_histogram.sql",
         "exportQueryFile": "statistics/exports/regions_asn.sql",
         "dataset": "statistics",
         "table": "regions_asn",
-        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "cities_asn": {
         "histogramQueryFile": "statistics/queries/continent_country_region_city_asn_histogram.sql",
         "exportQueryFile": "statistics/exports/cities_asn.sql",
         "dataset": "statistics",
         "table": "cities_asn",
-        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .city }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/{{ .continent_code }}/{{ .country_code }}/{{ .ISO3166_2region1 }}/{{ .city }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "states_asn": {
         "histogramQueryFile": "statistics/queries/us_state_territories_asn_histogram.sql",
         "exportQueryFile": "statistics/exports/us_states_asn.sql",
         "dataset": "statistics",
         "table": "us_states_asn",
-        "outputPath": "v0/NA/US/states/{{ .GEOID }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/NA/US/states/{{ .GEOID }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "counties_asn": {
         "histogramQueryFile": "statistics/queries/us_county_asn_histogram.sql",
         "exportQueryFile": "statistics/exports/us_counties_asn.sql",
         "dataset": "statistics",
         "table": "us_counties_asn",
-        "outputPath": "v0/NA/US/counties/{{ .GEOID }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/NA/US/counties/{{ .GEOID }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "tracts_asn": {
         "histogramQueryFile": "statistics/queries/us_census_tracts_asn_histogram.sql",
         "exportQueryFile": "statistics/exports/us_tracts_asn.sql",
         "dataset": "statistics",
         "table": "us_tracts_asn",
-        "outputPath": "v0/NA/US/tracts/{{ .GEOID }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/NA/US/tracts/{{ .GEOID }}/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     },
     "global_asn": {
         "histogramQueryFile": "statistics/queries/global_asn_histogram.sql",
         "exportQueryFile": "statistics/exports/global_asn.sql",
         "dataset": "statistics",
         "table": "global_asn",
-        "outputPath": "v0/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json"
+        "outputPath": "v0/asn/{{ .asn }}/{{ .year }}/histogram_daily_stats.json",
+        "dateField": "date",
+        "partitionField": "shard",
+        "partitionType": "range"
     }
 }

--- a/pipeline/handlers.go
+++ b/pipeline/handlers.go
@@ -18,9 +18,9 @@ import (
 const dateFormat = "2006-01-02"
 
 var (
-	newHistogramTable = func(name, ds, query string,
+	newHistogramTable = func(name, ds string, config histogram.QueryConfig,
 		client bqiface.Client) HistogramTable {
-		return histogram.NewTable(name, ds, query, client)
+		return histogram.NewTable(name, ds, config, client)
 	}
 )
 
@@ -189,7 +189,14 @@ func (h *Handler) generateHistogramForYear(ctx context.Context,
 	}
 	// Append year to the table name from the config.
 	table := fmt.Sprintf("%s_%s", config.Table, year)
-	hist := newHistogramTable(table, config.Dataset, string(content),
+
+	queryConfig := histogram.QueryConfig{
+		Query:          string(content),
+		DateField:      config.DateField,
+		PartitionField: config.PartitionField,
+		PartitionType:  config.PartitionType,
+	}
+	hist := newHistogramTable(table, config.Dataset, queryConfig,
 		h.bqClient)
 	start, err := time.Parse(dateFormat, year+"-01-01")
 	if err != nil {

--- a/pipeline/handlers_test.go
+++ b/pipeline/handlers_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"github.com/m-lab/stats-pipeline/config"
+	"github.com/m-lab/stats-pipeline/histogram"
 )
 
 type mockClient struct {
@@ -44,7 +45,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		},
 	}
 
-	newHistogramTable = func(name, ds, query string,
+	newHistogramTable = func(name, ds string, config histogram.QueryConfig,
 		client bqiface.Client) HistogramTable {
 		return &mockHistogramTable{}
 	}


### PR DESCRIPTION
This PR adds three new configuration options to the "histogram" phase (which I'm considering to rename to "query execution" or some other more generic name):
- partitioningField: the field to use to partition the output table (can be blank)
- partitioningType: the type of partitioning to use ("time" / "range" - e.g. the canary query would use `time` here, while all the existing queries would use `range` over the `shard` field)
- dateField: the DATE field to use to remove the existing rows when updating a time range. It will be different from `partitioningField` when`partitioningType` is `range`, and it's mandatory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/68)
<!-- Reviewable:end -->
