### PR TITLE
update two subqueries that had the wrong table name

### DIFF
--- a/statistics/queries/us_state_territories_asn_histogram.sql
+++ b/statistics/queries/us_state_territories_asn_histogram.sql
@@ -162,7 +162,7 @@ ul_per_location AS (
     id,
     a.MeanThroughputMbps AS mbps,
     a.MinRTT AS MinRTT
-  FROM `measurement-lab.ndt.unified_downloads`, us_states
+  FROM `measurement-lab.ndt.unified_uploads`, us_states
   WHERE date BETWEEN @startdate AND @enddate
   AND ST_WITHIN(
     ST_GeogPoint(

--- a/statistics/queries/us_state_territories_histogram.sql
+++ b/statistics/queries/us_state_territories_histogram.sql
@@ -155,7 +155,7 @@ ul_per_location AS (
     id,
     a.MeanThroughputMbps AS mbps,
     a.MinRTT AS MinRTT
-  FROM `measurement-lab.ndt.unified_downloads`, us_states
+  FROM `measurement-lab.ndt.unified_uploads`, us_states
   WHERE date BETWEEN @startdate AND @enddate
   AND ST_WITHIN(
     ST_GeogPoint(


### PR DESCRIPTION
Updates two sub-queries that referred to the wrong table. Once reviewed and merged, the two currently available years (2020, 2021) of stats for these two queries will need to be re-run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/70)
<!-- Reviewable:end -->
