### PR TITLE
Add exporter type flag and base for annotation export

### DIFF
--- a/cmd/stats-pipeline/main.go
+++ b/cmd/stats-pipeline/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/m-lab/go/uploader"
 	"github.com/m-lab/stats-pipeline/config"
 	"github.com/m-lab/stats-pipeline/exporter"
+	"github.com/m-lab/stats-pipeline/exporter/types"
 	"github.com/m-lab/stats-pipeline/output"
 	"github.com/m-lab/stats-pipeline/pipeline"
 )
@@ -90,7 +91,7 @@ func main() {
 	case "stats":
 		exp = exporter.New(bqiface.AdaptClient(bqClient), project, wr)
 	case "annotation":
-		panic("TODO(soltesz): implement annotation exporter")
+		exp = types.New(bqiface.AdaptClient(bqClient), project, wr)
 	case "hopannotation1":
 		panic("TODO: implement hopannotation1 exporter")
 	}

--- a/exporter/types/annotation.go
+++ b/exporter/types/annotation.go
@@ -1,0 +1,543 @@
+package exporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"regexp"
+	"sync"
+	"sync/atomic"
+	"text/template"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
+	"github.com/m-lab/stats-pipeline/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/api/iterator"
+)
+
+// Field used for partitioning tables. Must match what is used in the histogram
+// queries.
+const partitionField = "shard"
+
+var (
+	fieldRegex           = regexp.MustCompile(`{{\s*\.([A-Za-z0-9_]+)\s*}}`)
+	bytesProcessedMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "stats_pipeline_exporter_bytes_processed",
+		Help: "Bytes processed by the exporter",
+	}, []string{
+		"table",
+	})
+
+	cacheHitMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "stats_pipeline_exporter_cache_hits",
+		Help: "Number of cache hits",
+	}, []string{
+		"table",
+	})
+
+	uploadedBytesMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "stats_pipeline_exporter_uploaded_bytes",
+		Help: "Bytes uploaded to GCS",
+	}, []string{
+		"table",
+	})
+
+	queryTotalMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "stats_pipeline_exporter_queries",
+		Help: "Export queries to be processed for the current table",
+	}, []string{
+		"table",
+	})
+
+	queryProcessedMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "stats_pipeline_exporter_queries_processed",
+		Help: "Queries processed for the current table",
+	}, []string{
+		"table",
+	})
+
+	inFlightUploadsHistogram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "stats_pipeline_exporter_inflight_uploads",
+			Help:    "Inflight uploads histogram",
+			Buckets: []float64{1, 2, 4, 8, 16},
+		},
+		[]string{"table"},
+	)
+
+	// Histogram bucket to record the upload queue size.
+	uploadQueueSizeHistogram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "stats_pipeline_exporter_uploads_queue_size",
+			Help:    "Upload queue size histogram",
+			Buckets: []float64{0, 1, 2, 4, 8},
+		},
+		[]string{"table"},
+	)
+
+	// Number of goroutines for querying BQ.
+	nQueryWorkers = flag.Int("exporter.query-workers", 15,
+		"Number of goroutines to use for parallel querying")
+
+	// Name of the field used to partition tables.
+	nUploadWorkers = flag.Int("exporter.upload-workers", 30,
+		"Number of goroutines to use for parallel upload")
+)
+
+// Convenience type for a bigquery row.
+type bqRow = map[string]bigquery.Value
+
+// Writer defines the interface for saving files to GCS or locally.
+type Writer interface {
+	Write(ctx context.Context, path string, content []byte) error
+}
+
+// JSONExporter is a JSON exporter for histogram data on BigQuery.
+type JSONExporter struct {
+	bqClient  bqiface.Client
+	projectID string
+	output    Writer
+
+	queryJobs  chan *QueryJob
+	uploadJobs chan *UploadJob
+	results    chan UploadResult
+
+	queriesDone     int32
+	uploadQLen      int32
+	inflightUploads int32
+}
+
+// UploadJob is a job for uploading data to a GCS bucket.
+type UploadJob struct {
+	table   string
+	objName string
+	content []byte
+}
+
+// UploadResult is the result of a GCS upload.
+type UploadResult struct {
+	objName string
+	err     error
+}
+
+// QueryJob is a job for running queries on BQ.
+type QueryJob struct {
+	name       string
+	query      string
+	fields     []string
+	outputPath *template.Template
+}
+
+// New creates a new JSONExporter.
+func New(bqClient bqiface.Client, projectID string, output Writer) *JSONExporter {
+	return &JSONExporter{
+		bqClient:  bqClient,
+		projectID: projectID,
+		output:    output,
+
+		queryJobs:  make(chan *QueryJob),
+		uploadJobs: make(chan *UploadJob),
+		results:    make(chan UploadResult),
+	}
+}
+
+// Export runs the provided SQL query and, for each row in the result, uploads
+// a file to the provided config.OutputPath on GCS. This file contains the JSON
+// representation of the rows.
+// config.OutputPath is a template whose parameters are provided by the BigQuery
+// row's fields. If a field is present in the output path, it's removed from the
+// BigQuery row's JSON representation, to reduce redundancy.
+//
+// e.g. if outputPath is "{{ .year }}/output.json" and we have a row per year,
+// the histograms will be uploaded to:
+// - 2010/output.json
+// - 2020/output.json
+// - etc.
+//
+// If any of the steps (running the query, reading the result, marshalling,
+// uploading) fails, this function returns the corresponding error.
+//
+// Note: config.OutputPath should not start with a "/".
+func (exporter *JSONExporter) Export(ctx context.Context,
+	config config.Config, queryTpl *template.Template,
+	year string) error {
+
+	// Retrieve list of fields from the output path template string.
+	fields, err := getFieldsFromPath(config.OutputPath)
+	if err != nil {
+		return err
+	}
+	log.Printf("Fields: %s", fields)
+
+	// Make output path template.
+	outputPath, err := template.New("outputPath").Parse(config.OutputPath)
+	if err != nil {
+		return err
+	}
+
+	// The fully qualified name for a table is project.dataset.table_year.
+	sourceTable := fmt.Sprintf("%s.%s.%s_%s", exporter.projectID, config.Dataset,
+		config.Table, year)
+	// The table_year format is used in some metrics.
+	tableName := fmt.Sprintf("%s_%s", config.Table, year)
+
+	// Generate WHERE clauses to shard the export query.
+	clauses, err := exporter.getPartitionFilters(ctx, sourceTable)
+	if err != nil {
+		log.Print(err)
+		return err
+	}
+
+	// Create channels for query/upload jobs and results.
+	exporter.queryJobs = make(chan *QueryJob)
+	exporter.uploadJobs = make(chan *UploadJob)
+	exporter.results = make(chan UploadResult)
+
+	// Set counters to zero.
+	exporter.uploadQLen = 0
+	exporter.inflightUploads = 0
+	exporter.queriesDone = 0
+
+	// Reset metrics for this table to zero.
+	resetMetrics(tableName)
+	inFlightUploadsHistogram.Reset()
+	uploadQueueSizeHistogram.Reset()
+
+	// The number of queries to run is the same as the number of clauses
+	// generated earlier.
+	queryTotalMetric.WithLabelValues(tableName).Set(float64(len(clauses)))
+
+	// Start a goroutine to print statistics periodically.
+	printStatsCtx, cancelPrintStats := context.WithCancel(ctx)
+	go exporter.printStats(printStatsCtx, len(clauses))
+	defer cancelPrintStats()
+
+	queryWg := sync.WaitGroup{}
+	// Create queryWorkers.
+	for w := 1; w <= *nQueryWorkers; w++ {
+		queryWg.Add(1)
+		log.Printf("Created queryWorker with ID: %d\n", w)
+		go exporter.queryWorker(ctx, &queryWg)
+	}
+
+	// Create uploadWorkers.
+	uploadWg := sync.WaitGroup{}
+	for w := 1; w <= *nUploadWorkers; w++ {
+		uploadWg.Add(1)
+		go exporter.uploadWorker(ctx, &uploadWg)
+	}
+
+	for _, v := range clauses {
+		// Execute the query template and send the query to one of the
+		// available queryWorker functions.
+		var buf bytes.Buffer
+		err = queryTpl.Execute(&buf, map[string]string{
+			"sourceTable": sourceTable,
+			"whereClause": v,
+		})
+		if err != nil {
+			log.Print(err)
+			break
+		}
+		select {
+		case <-ctx.Done():
+			// If the context has been closed, we stop writing to the channel.
+			break
+		default:
+			exporter.queryJobs <- &QueryJob{
+				name:       tableName,
+				query:      buf.String(),
+				fields:     fields,
+				outputPath: outputPath,
+			}
+			// Atomically increase the queriesDone counter and update metric.
+			atomic.AddInt32(&exporter.queriesDone, 1)
+			queryProcessedMetric.WithLabelValues(tableName).Inc()
+		}
+	}
+	// The goroutines' termination is controlled by closing the channels they
+	// work on. The fist WaitGroup makes sure all the query workers have been
+	// terminated before terminating the upload workers. The second one makes
+	// sure all the upload workers have been terminated before returning.
+	close(exporter.queryJobs)
+	queryWg.Wait()
+	close(exporter.uploadJobs)
+	uploadWg.Wait()
+	return nil
+}
+
+// queryWorker reads the next available QueryJob from the queryJobs channel and
+// processes the result.
+func (exporter *JSONExporter) queryWorker(ctx context.Context,
+	wg *sync.WaitGroup) {
+
+	// Make sure we decrement the waitgroup's counter before returning.
+	defer wg.Done()
+
+	for j := range exporter.queryJobs {
+		// Run the SELECT query to get histogram data.
+		log.Printf("Running query: %s", j.query)
+		q := exporter.bqClient.Query(j.query)
+		job, err := q.Run(ctx)
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		jobStatus, err := job.Wait(ctx)
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		if jobStatus.Err() != nil {
+			log.Print(err)
+			continue
+		}
+		it, err := job.Read(ctx)
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		// Update bytes processed.
+		if queryDetails, ok := jobStatus.Statistics.Details.(*bigquery.QueryStatistics); ok {
+			if queryDetails.CacheHit {
+				cacheHitMetric.WithLabelValues(j.name).Inc()
+			}
+			bytesProcessedMetric.WithLabelValues(j.name).Add(float64(queryDetails.TotalBytesProcessed))
+		}
+		// Iterate over the returned rows and upload results to GCS.
+		err = exporter.processQueryResults(it, j)
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+	}
+}
+
+// processQueryResults loops over a RowIterator.
+// For each row it generates a row key combining the fields in QueryJob.fields.
+// When the row key changes, it means a file containing the rows read so far
+// is ready to be uploaded, so the rows are marshalled and sent to the
+// uploadJobs channel.
+//
+// For every UploadJob sent over the channel, it also atomically increments
+// uploadCounter.
+func (exporter *JSONExporter) processQueryResults(it bqiface.RowIterator,
+	j *QueryJob) error {
+	var currentFile []bqRow
+	var lastRow bqRow
+	var currentRow bqRow
+	var err error
+	// Setting MaxSize here allows to fetch more rows with a single fetch.
+	it.PageInfo().MaxSize = 100000
+
+	for err = it.Next(&currentRow); err == nil; err = it.Next(&currentRow) {
+		// If any of j.fields changed between this row and the previous one,
+		// upload the current file. Ignore the first row.
+		if lastRow != nil {
+			for _, f := range j.fields {
+				if currentRow[f] != lastRow[f] {
+					// upload file, empty currentFile, break
+					exporter.uploadFile(j, currentFile, lastRow)
+					currentFile = nil
+					break
+				}
+			}
+		}
+		// We are in the middle or start of a file, so just append the current
+		// row to currentFile. The partitionField is removed from the output.
+		currentFile = append(currentFile, removeFieldsFromRow(currentRow,
+			[]string{}))
+		// Save relevant fields for comparison in the next iteration.
+		// Note: we can't just do lastRow = currentRow here as it would be a
+		// reference; we need to copy.
+		if lastRow == nil {
+			lastRow = make(bqRow)
+		}
+		for _, f := range j.fields {
+			lastRow[f] = currentRow[f]
+		}
+	}
+
+	if err == iterator.Done {
+		// If this was the last row, upload the file so far.
+		exporter.uploadFile(j, currentFile, lastRow)
+		// This is the expected behavior, so we don't consider this an error.
+		return nil
+	}
+
+	return err
+}
+
+// uploadFile marshals the BigQuery rows and uploads the resulting JSON to the
+// GCS path defined in the QueryJob. Template variables are taken from the
+// first row in the slice.
+func (exporter *JSONExporter) uploadFile(j *QueryJob, rows []bqRow, lastRow bqRow) error {
+	if len(rows) == 0 {
+		return errors.New("empty rows slice")
+	}
+	buf := new(bytes.Buffer)
+	// Use the first row to fill in the template variables.
+	err := j.outputPath.Execute(buf, lastRow)
+	if err != nil {
+		return err
+	}
+	atomic.AddInt32(&exporter.uploadQLen, 1)
+	marshalAndUpload(j.name, buf.String(), rows, exporter.uploadJobs)
+	return nil
+}
+
+// uploadWorker receives UploadJobs from the channel and uploads files to GCS.
+func (exporter *JSONExporter) uploadWorker(ctx context.Context, wg *sync.WaitGroup) {
+
+	// Make sure we decrement the waitgroup's counter before returning.
+	defer wg.Done()
+
+	for j := range exporter.uploadJobs {
+		// The uploadQueue counter is decremented before starting to upload
+		// the file, so that in-flight uploads aren't counted.
+		// After this, we observe the size of the upload queue and put its
+		// length in a Prometheus metric.
+		atomic.AddInt32(&exporter.uploadQLen, -1)
+		uploadQueueSizeHistogram.WithLabelValues(j.table).Observe(float64(
+			atomic.LoadInt32(&exporter.uploadQLen)))
+
+		atomic.AddInt32(&exporter.inflightUploads, 1)
+		inFlightUploadsHistogram.WithLabelValues(j.table).Observe(float64(
+			atomic.LoadInt32(&exporter.inflightUploads)))
+		err := exporter.output.Write(ctx, j.objName, j.content)
+		atomic.AddInt32(&exporter.inflightUploads, -1)
+
+		uploadedBytesMetric.WithLabelValues(j.table).Add(float64(len(j.content)))
+		exporter.results <- UploadResult{
+			objName: j.objName,
+			err:     err,
+		}
+	}
+}
+
+// getPartitionFilters returns all the WHERE clauses to filter by partition,
+// sorted by decreasing size. This allows to process the largest partitions
+// first.
+// E.g. if partitionField is continent_code_hash, this will return 7 clauses:
+// - WHERE continent_code_hash = <partition>
+// - [...]
+func (exporter *JSONExporter) getPartitionFilters(ctx context.Context,
+	fullyQualifiedTable string) ([]string, error) {
+	selectQuery := fmt.Sprintf(`SELECT %s FROM %s GROUP BY %[1]s
+		ORDER BY COUNT(*) DESC`, partitionField, fullyQualifiedTable)
+	log.Print(selectQuery)
+	q := exporter.bqClient.Query(selectQuery)
+	it, err := q.Read(ctx)
+	if err != nil {
+		log.Print(err)
+		return nil, err
+	}
+	// Generate the complete where clause for each query.
+	var clauses []string
+	for {
+		var row bqRow
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		partition := row[partitionField].(int64)
+		clauses = append(clauses, fmt.Sprintf("WHERE %s = %d", partitionField, partition))
+	}
+	return clauses, nil
+}
+
+// marshalAndUpload marshals the BigQuery rows into a JSON array and sends a
+// new UploadJob to the uploadJobs channel so the result is uploaded to GCS as
+// objName.
+func marshalAndUpload(tableName, objName string, rows []bqRow,
+	uploadJobs chan<- *UploadJob) error {
+	j, err := json.Marshal(rows)
+	if err != nil {
+		return err
+	}
+
+	uploadJobs <- &UploadJob{
+		table:   tableName,
+		objName: objName,
+		content: j,
+	}
+	return nil
+}
+
+// printStats prints statistics about the ongoing export every second.
+func (exporter *JSONExporter) printStats(ctx context.Context, totQueries int) {
+	uploaded := 0
+	errors := 0
+	start := time.Now()
+	t := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case res := <-exporter.results:
+			if res.err != nil {
+				errors++
+			} else {
+				uploaded++
+			}
+		case <-t.C:
+			log.Printf(
+				"Elapsed: %s, queries: %d/%d, uploaded: %d (%d errors), files/s: %f, UL queue: %d",
+				time.Since(start).Round(time.Second).String(),
+				atomic.LoadInt32(&exporter.queriesDone), totQueries, uploaded, errors,
+				float64(uploaded)/time.Since(start).Seconds(),
+				atomic.LoadInt32(&exporter.uploadQLen))
+		}
+	}
+}
+
+// getFieldsFromPath takes the outputPath template string and returns the
+// fields matched by the capture group in fieldRegex.
+func getFieldsFromPath(path string) ([]string, error) {
+	var fields []string
+	matches := fieldRegex.FindAllStringSubmatch(path, -1)
+	if len(matches) == 0 {
+		return nil, errors.New("no fields found in the path template")
+	}
+	for _, m := range matches {
+		fields = append(fields, m[1])
+	}
+	return fields, nil
+}
+
+// removeFieldsFromRow returns a new BQ row without the specified fields. It
+// also removes the partitioning field if present.
+func removeFieldsFromRow(row bqRow, fields []string) bqRow {
+	newRow := bqRow{}
+	fields = append(fields, partitionField)
+	for fieldName, fieldValue := range row {
+		found := false
+		for _, k := range fields {
+			if fieldName == k {
+				found = true
+			}
+		}
+		if !found {
+			newRow[fieldName] = fieldValue
+		}
+	}
+	return newRow
+}
+
+// resetMetrics sets all the metrics for a given table to zero.
+func resetMetrics(tableName string) {
+	queryProcessedMetric.WithLabelValues(tableName).Set(0)
+	uploadedBytesMetric.WithLabelValues(tableName).Set(0)
+	bytesProcessedMetric.WithLabelValues(tableName).Set(0)
+	cacheHitMetric.WithLabelValues(tableName).Set(0)
+}

--- a/exporter/types/annotation.go
+++ b/exporter/types/annotation.go
@@ -1,4 +1,4 @@
-package exporter
+package types
 
 import (
 	"bytes"

--- a/exporter/types/annotation_test.go
+++ b/exporter/types/annotation_test.go
@@ -1,0 +1,356 @@
+package exporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"reflect"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/m-lab/stats-pipeline/output"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
+	"github.com/m-lab/go/cloudtest/bqfake"
+	"github.com/m-lab/go/cloudtest/gcsfake"
+	"github.com/m-lab/go/prometheusx/promtest"
+	"github.com/m-lab/go/testingx"
+	"github.com/m-lab/go/uploader"
+	"google.golang.org/api/iterator"
+)
+
+// BigQuery mocks to allow for testing with fake data.
+// ***** mockClient *****
+type mockClient struct {
+	bqiface.Client
+
+	// queryReadMustFail controls whether the Read() method will fail for
+	// queries created by this client object.
+	queryReadMustFail bool
+
+	// queries stores every query run through this client so it can be
+	// checked later in tests.
+	queries []string
+
+	// iterator is the fake iterator every query will return.
+	// Allows to provide fake query results.
+	iterator bqiface.RowIterator
+}
+
+func (c *mockClient) Dataset(name string) bqiface.Dataset {
+	return &mockDataset{
+		name: name,
+	}
+}
+
+func (c *mockClient) Query(query string) bqiface.Query {
+	return &mockQuery{
+		client:       c,
+		q:            query,
+		readMustFail: c.queryReadMustFail,
+		iterator:     c.iterator,
+	}
+}
+
+// ***** mockDataset *****
+type mockDataset struct {
+	bqiface.Dataset
+	name string
+}
+
+func (ds *mockDataset) Table(name string) bqiface.Table {
+	return &mockTable{
+		ds:   ds.name,
+		name: name,
+	}
+}
+
+// ***** mockTable *****
+type mockTable struct {
+	bqiface.Table
+	ds   string
+	name string
+}
+
+func (t *mockTable) DatasetID() string {
+	return t.ds
+}
+
+func (t *mockTable) TableID() string {
+	return t.name
+}
+
+// ********** mockQuery **********
+type mockQuery struct {
+	bqiface.Query
+	client       *mockClient
+	q            string
+	qc           bqiface.QueryConfig
+	readMustFail bool
+	runMustFail  bool
+	iterator     bqiface.RowIterator
+}
+
+func (q *mockQuery) Read(context.Context) (bqiface.RowIterator, error) {
+	if q.readMustFail {
+		return nil, errors.New("Read() failed")
+	}
+	// Store the query's content into the client so it can be checked later.
+	q.client.queries = append(q.client.queries, q.q)
+	return q.iterator, nil
+}
+
+func (q *mockQuery) SetQueryConfig(qc bqiface.QueryConfig) {
+	q.qc = qc
+}
+
+// ***** mockRowIterator *****
+type mockRowIterator struct {
+	bqiface.RowIterator
+
+	iterErr error
+	rows    []map[string]bigquery.Value
+	index   int
+}
+
+func (it *mockRowIterator) PageInfo() *iterator.PageInfo {
+	return &iterator.PageInfo{}
+}
+
+func (it *mockRowIterator) Next(dst interface{}) error {
+	// Check config for an error.
+	if it.iterErr != nil {
+		return it.iterErr
+	}
+	// Allow an empty config to return Done.
+	if it.index >= len(it.rows) {
+		return iterator.Done
+	}
+	v := dst.(*map[string]bigquery.Value)
+	*v = it.rows[it.index]
+	it.index++
+	return nil
+}
+
+func (it *mockRowIterator) Reset() {
+	it.index = 0
+}
+
+func TestNew(t *testing.T) {
+	bq, err := bqfake.NewClient(context.Background(), "test")
+	testingx.Must(t, err, "cannot init bq client")
+	gcs := &gcsfake.GCSClient{}
+	wr := output.NewGCSWriter(uploader.New(gcs, "test-bucket"))
+	exporter := New(bq, "project", wr)
+	if exporter == nil {
+		t.Fatalf("New() returned nil.")
+	}
+	if exporter.bqClient != bq || exporter.output != wr ||
+		exporter.projectID != "project" {
+		t.Errorf("New() didn't return the expected exporter instance")
+	}
+}
+
+func TestJSONExporter_marshalAndUpload(t *testing.T) {
+	jobs := make(chan *UploadJob)
+	fakeRow := bqRow{
+		"field": "value",
+	}
+	rows := []bqRow{fakeRow}
+	go func() {
+		err := marshalAndUpload("tablename", "test", rows, jobs)
+		if err != nil {
+			t.Errorf("marshalAndUpload() returned err: %v", err)
+		}
+		close(jobs)
+	}()
+	// Read from the channel. If the channel is closed and nothing has been
+	// sent, the function failed.
+	if job, ok := <-jobs; ok {
+		if job.objName != "test" || len(job.content) == 0 {
+			t.Errorf("marshalAndUpload() didn't send the expected value")
+		}
+	} else {
+		t.Errorf("marshalAndUpload() didn't send a value")
+	}
+
+	// Call marshalAndUpload with a row that cannot be marshalled.
+	unmarshallableRow := bqRow{
+		"this-will-fail": make(chan int),
+	}
+	rows = append(rows, unmarshallableRow)
+	jobs = make(chan *UploadJob)
+	go func() {
+		err := marshalAndUpload("tablename", "this-will-fail", rows, jobs)
+		if err == nil {
+			t.Errorf("marshalAndUpload(): expected error, got nil")
+		}
+		close(jobs)
+	}()
+	// We don't expect anything on the channel.
+	if _, ok := <-jobs; ok {
+		t.Errorf("marshalAndUpload() sent an unexpected job after an error")
+	}
+}
+
+func Test_printStats(t *testing.T) {
+	out := new(bytes.Buffer)
+	log.SetOutput(out)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bq, err := bqfake.NewClient(context.Background(), "test")
+	testingx.Must(t, err, "cannot init bq client")
+	gcs := &gcsfake.GCSClient{}
+	wr := output.NewGCSWriter(uploader.New(gcs, "test-bucket"))
+	exporter := New(bq, "project", wr)
+
+	go exporter.printStats(ctx, 1)
+	// Send a successful upload and an error, then check the output after a
+	// second.
+	exporter.results <- UploadResult{
+		objName: "test",
+	}
+	exporter.results <- UploadResult{
+		objName: "failed",
+		err:     errors.New("upload failed"),
+	}
+
+	time.Sleep(2 * time.Second)
+	if !strings.Contains(out.String(), "uploaded: 1") ||
+		!strings.Contains(out.String(), "1 errors") {
+		t.Errorf("printStats() didn't print the expected output: %v", out.String())
+	}
+}
+
+func Test_getFieldsFromPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			path: "{{ .foo }}/{{.bar}}",
+			want: []string{"foo", "bar"},
+		},
+		{
+			name:    "no-matches",
+			path:    "{{foo}}/{{bar}}",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getFieldsFromPath(tt.path)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getFieldsFromPath() = %v, want %v", got, tt.want)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("exporter.getFieldsFromPath() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_removeFieldsFromRow(t *testing.T) {
+	fakeRow := bqRow{
+		"test":   "foo",
+		"remove": "this",
+	}
+	tests := []struct {
+		name   string
+		row    bqRow
+		fields []string
+		want   bqRow
+	}{
+		{
+			name:   "ok-field-removed",
+			row:    fakeRow,
+			fields: []string{"remove"},
+			want: bqRow{
+				"test": "foo",
+			},
+		},
+		{
+			name:   "not-found-return-original-row",
+			row:    fakeRow,
+			fields: []string{"non-existing-field"},
+			want:   fakeRow,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeFieldsFromRow(tt.row, tt.fields); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeFieldsFromRow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPrometheusMetrics ensures that all the metrics pass the linter.
+func TestPrometheusMetrics(t *testing.T) {
+	bytesProcessedMetric.WithLabelValues("x")
+	cacheHitMetric.WithLabelValues("x")
+	uploadedBytesMetric.WithLabelValues("x")
+	queryTotalMetric.WithLabelValues("x")
+	queryProcessedMetric.WithLabelValues("x")
+	inFlightUploadsHistogram.WithLabelValues("x")
+	uploadQueueSizeHistogram.WithLabelValues("x")
+
+	promtest.LintMetrics(t)
+}
+
+func TestJSONExporter_processQueryResults(t *testing.T) {
+	exporter := &JSONExporter{
+		uploadJobs: make(chan *UploadJob),
+	}
+	// Create an iterator returning a fake row.
+	it := &mockRowIterator{
+		rows: []map[string]bigquery.Value{
+			{
+				"date":  "2020-01-01",
+				"year":  2020,
+				"shard": int64(1),
+			},
+		},
+	}
+	outputPathTpl := template.Must(template.New("path").Parse(
+		"{{.year}}/output.json",
+	))
+	qJob := &QueryJob{
+		name:       "test",
+		query:      "SELECT * FROM test_table",
+		fields:     []string{"year"},
+		outputPath: outputPathTpl,
+	}
+	go exporter.processQueryResults(it, qJob)
+	// Read the job sent on the uploadJobs channel and check its content.
+	ul := <-exporter.uploadJobs
+	var rows []map[string]json.RawMessage
+	err := json.Unmarshal(ul.content, &rows)
+	if err != nil {
+		t.Errorf("Cannot unmarshal JSON: %v", err)
+	}
+
+	if len(rows) == 0 {
+		t.Fatal("Output JSON is empty")
+	}
+	row := rows[0]
+	if _, ok := row["shard"]; ok {
+		t.Errorf("the 'shard' field has not been removed from the output")
+	}
+	if string(row["date"]) != `"2020-01-01"` {
+		t.Errorf("wrong value for the date field: %v", string(row["date"]))
+	}
+	if string(row["year"]) != `2020` {
+		t.Errorf("wrong value for the year field: %v", string(row["year"]))
+	}
+}

--- a/exporter/types/annotation_test.go
+++ b/exporter/types/annotation_test.go
@@ -1,4 +1,4 @@
-package exporter
+package types
 
 import (
 	"bytes"


### PR DESCRIPTION
This change introduces a new flag to the stats-pipeline command: `-export`. Default behavior remains unchanged. This flag will allow the stats-pipeline to support the annotation export process by specifying an export type (along with a set of export queries).

This change also copies the current exporter/exporter.go (and tests) to the `types/` package *unmodified* (other than the package name). This copy will allow future PRs to easily highlight what changes are specific to the annotation export process and which are shared. Future changes may also eliminate duplicate code.

This change is part of the [Synthetic UUID annotations][1] export process.

[1]: https://docs.google.com/document/d/1Hdf7-FglNs5OXMBcAbO_b0HZZxP-4nkXPXnZwDlUEII/edit?resourcekey=0-eun68veHrU1Y0aNUJpAZdg#

@robertodauria - this changes the base stats-pipeline so I wanted your feedback on whether this change would be acceptable. Long term this functionality does not need to be preserved. But, the delta is small enough that it felt like a mistake to duplicate the entire repo (discussed conversationally).

@cristinaleonr - this is a template for how we can create a similar exporter for the hopannotation1 types. Future PRs will modify the current `types/annotation.go` to be annotation type specific including the export queries. And, I imagine a similar pattern working for the hopannotation1 export work. So, I wanted your feedback because I imagine you will be interacting with this directly.