### PR TITLE
Add stats query formatter

### DIFF
--- a/formatter/query.go
+++ b/formatter/query.go
@@ -1,0 +1,51 @@
+// Package formatter provides query formatters for export types supported by the stats pipeline.
+package formatter
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/stats-pipeline/config"
+)
+
+// StatsQueryFormatter prepares export queries for statstics in the stats pipeline.
+type StatsQueryFormatter struct{}
+
+// NewStatsQueryFormatter creates a new StatsQueryFormatter.
+func NewStatsQueryFormatter() *StatsQueryFormatter {
+	return &StatsQueryFormatter{}
+}
+
+// Source returns a fully qualified bigquery table name including a year suffix
+// used by the stats pipeline.
+func (f *StatsQueryFormatter) Source(project string, config config.Config, year int) string {
+	return fmt.Sprintf("%s.%s.%s_%d", project, config.Dataset, config.Table, year)
+}
+
+// Partitions returns a bigquery query for listing all partitions for a given
+// source table.
+func (f *StatsQueryFormatter) Partitions(source string) string {
+	return fmt.Sprintf(
+		`SELECT shard
+	    FROM %s
+		GROUP BY shard
+		ORDER BY COUNT(*) DESC`, source)
+}
+
+// Where returns a bigquery "WHERE" clause based on a row returned by running
+// the Partitions() query.
+func (f *StatsQueryFormatter) Where(row map[string]bigquery.Value) string {
+	partition := row["shard"].(int64)
+	return fmt.Sprintf("WHERE shard = %d", partition)
+}
+
+// Marshal converts an export query row into a byte result suitable for writing
+// to disk. For stats pipeline export, the format is JSON.
+func (f *StatsQueryFormatter) Marshal(rows []map[string]bigquery.Value) ([]byte, error) {
+	j, err := json.Marshal(rows)
+	if err != nil {
+		return nil, err
+	}
+	return j, nil
+}

--- a/formatter/query_test.go
+++ b/formatter/query_test.go
@@ -1,0 +1,130 @@
+// Package formatter provides query formatters for export types supported by the stats pipeline.
+package formatter
+
+import (
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/stats-pipeline/config"
+)
+
+func TestStatsQueryFormatter_Source(t *testing.T) {
+	tests := []struct {
+		name    string
+		project string
+		config  config.Config
+		year    int
+		want    string
+	}{
+		{
+			name:    "success",
+			project: "mlab-testing",
+			config: config.Config{
+				Dataset: "statistics",
+				Table:   "bananas",
+			},
+			year: 2019,
+			want: "mlab-testing.statistics.bananas_2019",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &StatsQueryFormatter{}
+			if got := f.Source(tt.project, tt.config, tt.year); got != tt.want {
+				t.Errorf("StatsQueryFormatter.Source() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatsQueryFormatter_Partitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "success",
+			source: "a.b.c",
+			want: `SELECT shard
+	    FROM a.b.c
+		GROUP BY shard
+		ORDER BY COUNT(*) DESC`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &StatsQueryFormatter{}
+			if got := f.Partitions(tt.source); got != tt.want {
+				t.Errorf("StatsQueryFormatter.Partitions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatsQueryFormatter_Where(t *testing.T) {
+	tests := []struct {
+		name string
+		row  map[string]bigquery.Value
+		want string
+	}{
+		{
+			name: "success",
+			row: map[string]bigquery.Value{
+				"shard": int64(1234),
+			},
+			want: "WHERE shard = 1234",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &StatsQueryFormatter{}
+			if got := f.Where(tt.row); got != tt.want {
+				t.Errorf("StatsQueryFormatter.Where() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatsQueryFormatter_Marshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		rows    []map[string]bigquery.Value
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "success",
+			rows: []map[string]bigquery.Value{
+				{
+					"test": 1234,
+				},
+			},
+			want: []byte(`[{"test":1234}]`),
+		},
+		{
+			name: "failure",
+			rows: []map[string]bigquery.Value{
+				{
+					// Functions are valid bigquery.Values but cannot be marshalled to JSON.
+					"test": func() {},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &StatsQueryFormatter{}
+			got, err := f.Marshal(tt.rows)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StatsQueryFormatter.Marshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StatsQueryFormatter.Marshal() = %q, want %q", string(got), string(tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a new package to the stats-pipeline repo: `formatter`. The formatter package contains implementations for formatting queries by the `exporter` package. The first query formatter is for the stats pipeline export (default behavior).

This package uses the same hard-coded queries currently found in the `exporter` package. A subsequent PR update the exporter to use a Formatter.

Additional formatters can be written for the "annotation" and "hopannotation1" export process and rely on a single exporter implementation.