### PR TITLE
Add annotation export config for local development

### DIFF
--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -1,0 +1,38 @@
+# Annotation Export
+
+Directions for running the stats-pipeline for annotation export using the
+alternate `config-annotation-export.json`.
+
+## Local development
+
+The `compose-annotation-export.yaml` specifies a docker compose configuration
+for running the stats-pipeline with an instance of pusher. Both services are
+able to use your local gcloud application default credentials.
+
+There are three "volumes" of interest:
+
+- `shared:/var/spool/ndt` - this is shared between the two containers,
+  stats-pipeline writes files, and the pusher archives, uploads, and removes them.
+- `/Users/soltesz/.config/gcloud/:/root/.config/gcloud` - this provides access
+  to your gcloud credentials. You must update the directory to your local home
+  path.
+- `/Users/soltesz/src/github.com/m-lab/stats-pipeline:/config` - this provides
+  access to the configuration and BigQuery SQL files in this repo.
+
+After updating the docker compose file to refer to your local home directories,
+you may run a local instance of the annotation export stats pipeline using
+docker-compose:
+
+```sh
+docker-compose -f compose-annotation-export.yaml build
+docker-compose -f compose-annotation-export.yaml up
+```
+
+NOTE: this will upload sample archives to the configured GCS bucket in
+mlab-sandbox. Those files don't matter b/c it's sandbox, but be careful to
+distinguish between new files created from your run and archives from previous
+runs.
+
+## Kubernetes
+
+TODO(soltesz): add notes for kubernetes configuration/deployment.

--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -13,14 +13,16 @@ There are three "volumes" of interest:
 
 - `shared:/var/spool/ndt` - this is shared between the two containers,
   stats-pipeline writes files, and the pusher archives, uploads, and removes them.
-- `/Users/soltesz/.config/gcloud/:/root/.config/gcloud` - this provides access
+- `$HOME/.config/gcloud/:/root/.config/gcloud` - this provides access
   to your gcloud credentials. You must update the directory to your local home
   path.
-- `/Users/soltesz/src/github.com/m-lab/stats-pipeline:/config` - this provides
-  access to the configuration and BigQuery SQL files in this repo.
+- `./:/config` - this provides access to the configuration and BigQuery SQL
+  files in this repo.
 
-After updating the docker compose file to refer to your local home directories,
-you may run a local instance of the annotation export stats pipeline using
+NOTE: Depending on your version of docker-compose, you may need to replace
+`$HOME` with your actual local directory name.
+
+You may run a local instance of the annotation export stats pipeline using
 docker-compose:
 
 ```sh

--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -35,6 +35,15 @@ mlab-sandbox. Those files don't matter b/c it's sandbox, but be careful to
 distinguish between new files created from your run and archives from previous
 runs.
 
+You may trigger the export process using:
+
+```sh
+curl -XPOST --data {} 'http://localhost:8080/v0/pipeline?step=exports&year=1'
+```
+
+Only the 'export' step is supported for annotation export, and the year is
+required but ignored.
+
 ## Kubernetes
 
 TODO(soltesz): add notes for kubernetes configuration/deployment.

--- a/annotation/exports/tcpinfo_annotation_export.sql
+++ b/annotation/exports/tcpinfo_annotation_export.sql
@@ -1,0 +1,29 @@
+-- Generate a synthetic UUID annotation from the base_tables.tcpinfo.
+--
+-- NOTES
+--
+-- For a single UUID, there may be multiple Timestamps per day in tcpinfo due to
+-- some long lived connections (probably not actual NDT measurements). The
+-- export query groups on the UUID and year_month_day to guarantee a single
+-- UUID per day. The query uses any Server and Client annotation from that day
+-- and the first (minimum) Timestamp.
+--
+-- This export query may be safely run multiple times *IF* the previously
+-- generated annotations have been copied to the ndt/annotation GCS location and
+-- parsed into the raw_ndt.annotation tables.
+SELECT
+    UUID,
+    MIN(TestTime) as Timestamp,
+    ANY_VALUE(ServerX) as Server,
+    ANY_VALUE(ClientX) as Client,
+    REPLACE(CAST(DATE(TestTime) AS STRING), "-", "/") as year_month_day,
+FROM `mlab-oti.base_tables.tcpinfo`
+{{ .whereClause }}
+    AND UUID != "" AND UUID is not NULL AND UUID NOT IN (
+        SELECT id FROM `mlab-oti.raw_ndt.annotation`
+    )
+    AND ServerX.Site != ""
+    AND ServerX.Geo is not NULL
+GROUP BY
+    UUID,
+    year_month_day

--- a/annotation/exports/tcpinfo_annotation_export.sql
+++ b/annotation/exports/tcpinfo_annotation_export.sql
@@ -14,8 +14,10 @@
 --
 -- The query uses the "Left Excluding JOIN" pattern to select only rows from
 -- TCPINFO *without* corresponding rows in the annotation table (i.e.
--- "annotation.id IS NULL"). This allows the query to filter on date partitions
--- which makes the query more efficient than a global search.
+-- "annotation.id IS NULL").
+--
+-- TODO(soltesz): Allows the query to filter on annotation date partitions
+-- to make the query more efficient than a global search.
 SELECT
     tcpinfo.UUID,
     MIN(tcpinfo.TestTime) as Timestamp,

--- a/compose-annotation-export.yaml
+++ b/compose-annotation-export.yaml
@@ -9,8 +9,8 @@ services:
     image: local-stats-pipeline
     volumes:
       - shared:/var/spool/ndt
-      - /Users/soltesz/.config/gcloud/:/root/.config/gcloud
-      - /Users/soltesz/src/github.com/m-lab/stats-pipeline:/config
+      - $HOME/.config/gcloud/:/root/.config/gcloud
+      - ./:/config
     ports:
       - target: 8080
         published: 8080
@@ -37,7 +37,7 @@ services:
     image: measurementlab/pusher:v1.19
     volumes:
       - shared:/var/spool/ndt
-      - /Users/soltesz/.config/gcloud/:/root/.config/gcloud
+      - $HOME/.config/gcloud/:/root/.config/gcloud
     network_mode: "service:annotation_export"
     command:
       - -prometheusx.listen-address=:9991

--- a/compose-annotation-export.yaml
+++ b/compose-annotation-export.yaml
@@ -1,0 +1,58 @@
+version: '3.7'
+volumes:
+  shared:
+services:
+  annotation_export:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: local-stats-pipeline
+    volumes:
+      - shared:/var/spool/ndt
+      - /Users/soltesz/.config/gcloud/:/root/.config/gcloud
+      - /Users/soltesz/src/github.com/m-lab/stats-pipeline:/config
+    ports:
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: host
+      - target: 9990
+        published: 9990
+        protocol: tcp
+        mode: host
+      - target: 9991
+        published: 9991
+        protocol: tcp
+        mode: host
+    command:
+      - -prometheusx.listen-address=:9990
+      - -exporter.query-workers=1
+      - -config=/config/config-annotation-export.json
+      - -output=local
+      - -export=annotation
+      - -bucket=/var/spool/ndt/annotation
+      - -project=mlab-sandbox
+
+  pusher:
+    image: measurementlab/pusher:v1.19
+    volumes:
+      - shared:/var/spool/ndt
+      - /Users/soltesz/.config/gcloud/:/root/.config/gcloud
+    network_mode: "service:annotation_export"
+    command:
+      - -prometheusx.listen-address=:9991
+      - -bucket=thirdparty-annotation-mlab-sandbox
+      - -experiment=ndt
+      - -datatype=annotation
+      - -directory=/var/spool/ndt
+      - -node_name=third-party
+      - -archive_size_threshold=20MB
+      - -max_file_age=10m               # No need to wait after writing to upload a file (default 1h).
+      - -archive_wait_time_min=15m      # (default 30m0s)
+      - -archive_wait_time_expected=30m # (default 1h0m0s)
+      - -archive_wait_time_max=1h       # (default 2h0m0s)
+      - -sigterm_wait_time=60s
+      - -metadata=MLAB.server.name=$HOSTNAME
+      - -metadata=MLAB.experiment.name=ndt
+      - -metadata=MLAB.pusher.image=measurementlab/pusher:v1.19
+      - -metadata=MLAB.pusher.src.url=https://github.com/m-lab/pusher/tree/v1.19

--- a/config-annotation-export.json
+++ b/config-annotation-export.json
@@ -1,0 +1,8 @@
+{
+    "tcpinfo": {
+        "exportQueryFile": "annotation/exports/tcpinfo_annotation_export.sql",
+        "dataset": "base_tables",
+        "table": "tcpinfo",
+        "outputPath": "{{ .year_month_day }}/{{ .UUID }}.json"
+    }
+}

--- a/config-annotation-export.json
+++ b/config-annotation-export.json
@@ -1,6 +1,6 @@
 {
     "tcpinfo": {
-        "exportQueryFile": "annotation/exports/tcpinfo_annotation_export.sql",
+        "exportQueryFile": "config/annotation/exports/tcpinfo_annotation_export.sql",
         "dataset": "base_tables",
         "table": "tcpinfo",
         "outputPath": "{{ .year_month_day }}/{{ .UUID }}.json"

--- a/formatter/annotation.go
+++ b/formatter/annotation.go
@@ -49,7 +49,11 @@ func (f *AnnotationQueryFormatter) Where(row map[string]bigquery.Value) string {
 	if !ok {
 		return "WHERE TRUE" // a noop expression.
 	}
-	return fmt.Sprintf("WHERE %s = DATE('%d-%02d-%02d')", f.DateExpr, partition.Year, int(partition.Month), partition.Day)
+	ds := fmt.Sprintf("%d-%02d-%02d", partition.Year, int(partition.Month), partition.Day)
+	template := `WHERE %s = DATE('%s') AND DATE('%s') BETWEEN
+            DATE_SUB(DATE(_PARTITIONTIME), INTERVAL 1 DAY)
+        AND DATE_ADD(DATE(_PARTITIONTIME), INTERVAL 1 DAY)`
+	return fmt.Sprintf(template, f.DateExpr, ds, ds)
 
 }
 

--- a/formatter/annotation_test.go
+++ b/formatter/annotation_test.go
@@ -78,7 +78,9 @@ func TestAnnotationQueryFormatter_Where(t *testing.T) {
 			row: map[string]bigquery.Value{
 				"date": civil.DateOf(time.Date(2020, time.June, 01, 0, 0, 0, 0, time.UTC)),
 			},
-			want: "WHERE DATE(TestTime) = DATE('2020-06-01')",
+			want: `WHERE DATE(TestTime) = DATE('2020-06-01') AND DATE('2020-06-01') BETWEEN
+            DATE_SUB(DATE(_PARTITIONTIME), INTERVAL 1 DAY)
+        AND DATE_ADD(DATE(_PARTITIONTIME), INTERVAL 1 DAY)`,
 		},
 		{
 			name: "error-missing-date",


### PR DESCRIPTION
This change adds a reference configuration for running the stats-pipeline in annotation export mode with the pusher. Together they can enumerate and generate synthetic uuid-annotation archives from the tcpinfo tables.

This change includes ANNOTATION.md with instructions for running the reference configuration for local development.

This change includes a new configuration directory `annotation` that includes an `exports` directory, following the structure of the `statatistics` directories. However, the `annotation` configuration will only ever include `exports`.

A subsequent PR will introduce the k8s configurations to run within the data-processing cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/77)
<!-- Reviewable:end -->
