### PR TITLE
Change canary query to use simpler client filter

### DIFF
--- a/statistics/queries/canary.sql
+++ b/statistics/queries/canary.sql
@@ -1,298 +1,161 @@
+# This query computes client
 # To invoke from command line:
-# bq query --use_legacy_sql=false --parameter='startdate:DATE:2021-07-05' --parameter='enddate:DATE:2021-07-07' < statistics/queries/canary.sql
-# bq query --use_legacy_sql=false --parameter='startdate:DATE:2021-07-05' --parameter='enddate:DATE:2021-08-30' --destination_table='mlab-sandbox:statistics.gfr' --time_partitioning_type=DAY --time_partitioning_field=test_date --replace  < statistics/queries/canary.sql
+# bq query --use_legacy_sql=false --parameter='startdate:DATE:2021-07-15' --parameter='enddate:DATE:2021-09-13' --destination_table='mlab-sandbox:statistics.gfr_stats2' --time_partitioning_type=DAY --time_partitioning_field=test_date --replace  < statistics/queries/canary_incorp_numbered.sql
 
 # TODO - identify slow and far clients, instead of individual tests.
 # Otherwise, we are filtering out potentially important outlier tests, instead of weird clients.
 
-WITH
-# This is the subset of data needed for the analysis.  It consists of about two
-# weeks of data, with metro, machine, and site broken out.
-primary AS (
-  SELECT date AS test_date, ID,
-  Client, Server,
-  REGEXP_EXTRACT(parser.ArchiveURL, ".*-(mlab[1-4])-.*") AS machine,
-  REGEXP_EXTRACT(parser.ArchiveURL, ".*-mlab[1-4]-([a-z]{3}[0-9]{2}).*") AS site,
-  REGEXP_EXTRACT(parser.ArchiveURL, ".*-mlab[1-4]-([a-z]{3})[0-9]{2}.*") AS metro,
-  TIMESTAMP_DIFF(raw.Download.EndTime, raw.Download.StartTime, MICROSECOND)/1000000 AS duration,
-  raw.clientIP,
-  IFNULL(raw.Download.ClientMetadata, raw.Upload.ClientMetadata) AS tmpClientMetaData,
-  raw.Download.UUID, # Use this instead of id or a.UUID to ensure we are only using Downloads (TODO??)
-  # Consider adding client-server geo distance and country
-  a.* EXCEPT(UUID)
+------------------------------------------------------------------------
+# NOTE: This block (all_tests and numbered_ndt7) will soon be broken out into a public view
+# and documented in a blog post.  This query will be updated at that time to use the public view.
+#
+# This decorates all NDT7 tests with additional fields:
+#  1. A synthetic ClientID
+#  2. Top level ServerMeasurements (either Upload or Download)
+#  3. NDTVersion, isDownload
+#  4. Additional fields in the client struct: Name, OS, Arch, Version, Library, LibraryVersion
+#. 4. Top level lastSnapshot (which may be NULL if there are no ServerMeasurements)
+#  5. Synthetic sequence numbers and counts per machine (machineSample/machineCount), site, and metro, to simplify client de-biasing.
+#  6. Top level elapsedTime based on last ServerMeasurement TCPInfo.ElapseTime value (or NULL if ServerMeasurements is empty).
+
+WITH all_tests AS (
+  SELECT ID, date, parser, 
+  (SELECT AS STRUCT server.*, LEFT(server.Site,3) AS Metro) AS server,
+  (SELECT AS STRUCT client.*, 
+    raw.clientIP IN
+      ("45.56.98.222", "35.192.37.249", "35.225.75.192", "23.228.128.99",
+      "2600:3c03::f03c:91ff:fe33:819",  "2605:a601:f1ff:fffe::99") AS isMonitoring,
+    (SELECT Value
+     FROM UNNEST(IFNULL(raw.Download.ClientMetadata, raw.Upload.ClientMetadata))
+     WHERE Name='client_name') AS Name,
+    (SELECT Value
+     FROM UNNEST(IFNULL(raw.Download.ClientMetadata, raw.Upload.ClientMetadata))
+     WHERE Name='client_os') AS OS,
+    (SELECT Value
+     FROM UNNEST(IFNULL(raw.Download.ClientMetadata, raw.Upload.ClientMetadata))
+     WHERE Name='client_arch') AS Arch,
+    (SELECT Value
+     FROM UNNEST(IFNULL(raw.Download.ClientMetadata, raw.Upload.ClientMetadata))
+     WHERE Name='client_library') AS Library,
+    (SELECT Value
+     FROM UNNEST(IFNULL(raw.Download.ClientMetadata, raw.Upload.ClientMetadata))
+     WHERE Name='client_version') AS Version,
+    (SELECT Value
+     FROM UNNEST(IFNULL(raw.Download.ClientMetadata, raw.Upload.ClientMetadata))
+     WHERE Name='client_library_version') AS LibraryVersion,
+    IFNULL(IFNULL(raw.Download.ServerMeasurements, raw.Upload.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo.wscale,-1) AS WScale,
+  ) AS client,
+  * EXCEPT(ID, date, parser, server, client),
+  
+  IF(raw.Download IS NULL, false, true) AS isDownload,
+  IFNULL(raw.Download.ServerMeasurements, raw.Upload.ServerMeasurements) AS ServerMeasurements,
+  REGEXP_EXTRACT(ID, "(ndt-?.*)-.*") AS NDTVersion,
   FROM `measurement-lab.ndt.ndt7`
-  WHERE date BETWEEN DATE_SUB(DATE(@startdate), INTERVAL 16 DAY) AND DATE(@enddate)
-  AND raw.Download IS NOT NULL
 ),
 
----------------------------------------------------------------------------
-add_client_name AS (
-  SELECT primary.* EXCEPT(tmpClientMetadata), clientName
-  FROM primary LEFT JOIN (
-    SELECT * EXCEPT(tmpClientMetadata, Name, Value), Value AS clientName
-    FROM primary, primary.tmpClientMetadata
-    WHERE Name = "client_name") cn USING (test_date, ID)
+numbered_ndt7 AS (
+SELECT *,
+  # This is an experimental ClientID, intended for exploration of how well it functions as a substitute for ClientIP.
+  FORMAT("%16X",FARM_FINGERPRINT(FORMAT("%s_%s_%s_%s_%s_%s_%s_%02x",
+    IFNULL(raw.ClientIP,"none"), IFNULL(client.Name,"none"), IFNULL(client.OS,"none"),
+    IFNULL(client.Arch, "none"), IFNULL(client.Version, "none"), IFNULL(client.Library, "none"), IFNULL(client.LibraryVersion, "none"),
+    IFNULL(ServerMeasurements[SAFE_OFFSET(0)].TCPInfo.wscale,-1)))) AS ClientID,
+  # This is a copy of the last snapshot, to make it more easily accessible, independent of whether it is an Upload or Download
+  ServerMeasurements[SAFE_ORDINAL(ARRAY_LENGTH(ServerMeasurements))] AS lastSnapshot,
+  # This may be a more useful elapsedTime measurement, since it reflects the available measurements.
+  ServerMeasurements[SAFE_ORDINAL(ARRAY_LENGTH(ServerMeasurements))].TCPInfo.ElapsedTime/1000000 AS elapsedTime,
+
+  # This assigns sample sequence numbers to each sample for a client on a machine.
+  # The xxxCount can be used in a MOD function to choose samples other than Sample = 1
+  ROW_NUMBER() OVER machineOrder AS machineSample, 
+  COUNT(*) OVER machinePart AS machineCount, #(PARTITION BY date, server.Site, server.Machine, raw.ClientIP, client.Name, client.OS, client.Version, client.Arch, client.Library, client.LibraryVersion, ServerMeasurements[SAFE_OFFSET(0)].TCPInfo.wscale, NDTVersion, isDownload) AS machineCount,
+  ROW_NUMBER() OVER siteOrder AS siteSample,
+  COUNT(*) OVER sitePart AS siteCount, #(PARTITION BY date, server.Site, raw.ClientIP, client.Name, client.OS, client.Version, client.Arch, client.Library, client.LibraryVersion, ServerMeasurements[SAFE_OFFSET(0)].TCPInfo.wscale, NDTVersion, isDownload) AS siteCount,
+  ROW_NUMBER() OVER metroOrder AS metroSample, 
+  COUNT(*) OVER metroPart AS metroCount, #(PARTITION BY date, server.Metro, raw.ClientIP, client.Name, client.OS, client.Version, client.Arch, client.Library, client.LibraryVersion, ServerMeasurements[SAFE_OFFSET(0)].TCPInfo.wscale, NDTVersion, isDownload) AS metroCount,
+FROM all_tests
+WINDOW
+  # Add random test numbers, per client/day, for uploads and downloads separately, and separately for each NDTVersion
+  # These are ordered by ARRAY_LENGTH(ServerMeasurements) DESC to prefer longer tests.
+  machinePart AS (PARTITION BY date, server.Site, server.Machine, raw.ClientIP, client.Name, client.OS, client.Version, client.Arch, client.Library, client.LibraryVersion, ServerMeasurements[SAFE_OFFSET(0)].TCPInfo.wscale, NDTVersion, isDownload),
+  machineOrder AS (machinePart ORDER BY ARRAY_LENGTH(ServerMeasurements) DESC, FARM_FINGERPRINT(ID)),
+  sitePart AS (PARTITION BY date, server.Site, raw.ClientIP, client.Name, client.OS, client.Version, client.Arch, client.Library, client.LibraryVersion, ServerMeasurements[SAFE_OFFSET(0)].TCPInfo.wscale, NDTVersion, isDownload),
+  siteOrder AS (sitePart ORDER BY ARRAY_LENGTH(ServerMeasurements) DESC, FARM_FINGERPRINT(ID)),
+  metroPart AS (PARTITION BY date, server.Metro, raw.ClientIP, client.Name, client.OS, client.Version, client.Arch, client.Library, client.LibraryVersion, ServerMeasurements[SAFE_OFFSET(0)].TCPInfo.wscale, NDTVersion, isDownload),
+  metroOrder AS (metroPart ORDER BY ARRAY_LENGTH(ServerMeasurements) DESC, FARM_FINGERPRINT(ID))
+),
+------------------------------------------------------------------------
+
+tests AS (
+  SELECT * EXCEPT(a), a.* FROM numbered_ndt7
+  WHERE NOT client.isMonitoring
 ),
 
----------------------------------------------------------------------------
-hours_per_machine AS (
-  SELECT
-    test_date,
-    TIMESTAMP_TRUNC(TestTime, HOUR) AS hour,
-    COUNT(uuid) AS tests, metro, site, machine,
-  FROM add_client_name
-  # Without this, the query costs goes up dramatically.
-  WHERE test_date BETWEEN DATE_SUB(DATE(@startdate), INTERVAL 16 DAY) AND DATE(@enddate)
-  GROUP BY test_date, hour, machine, site, metro
-),
-
----------------------------------------------------------------------------
-hours_per_day_per_machine AS (
-  SELECT
-    * EXCEPT(hour, tests),
-    COUNT(hour) AS hours, SUM(tests) AS tests,  # TODO - sometimes see 25 hours!!
-  FROM hours_per_machine
-  GROUP BY test_date, machine, site, metro
-),
-
-good_machines_per_metro AS (
-  SELECT
-    * EXCEPT(machine, hours, site, tests),
-    COUNT(machine) AS metro_machines, SUM(hours) AS metro_hours,
-    COUNTIF(hours = 24) AS good_machines, SUM(IF(hours = 24, hours, 0)) AS good_hours,
-    ARRAY_AGG( STRUCT( site, machine, tests, hours, hours = 24 AS good ) ORDER BY site, machine) AS machines,
-  FROM hours_per_day_per_machine
-  GROUP BY test_date, metro
-),
-
----------------------------------------------------------------------------
-# Tests per client, per machine and date.
-tests_per_client AS (
+subset AS (
 SELECT
-  test_date, TestTime,
-  metro, site, machine,
-  clientIP AS client,
-  UUID, # From Download
-#  MeanThroughputMbps AS mbps,
-FROM add_client_name
-WHERE duration BETWEEN 9 and 13
+  date AS test_date, TestTime, server.metro, server.site, server.machine, Client, Server,
+  ClientID,
+  NDTVersion,
+  UUID,
+  CongestionControl AS cc,
+  MeanThroughputMbps AS mbps,
+  lastSnapshot.TCPInfo.Retransmits,
+  MinRTT, # in msec
+  LossRate,
+  elapsedTime,
+  MeanThroughputMbps <= 0.1 AS slow,
+  elapsedTime BETWEEN 7 AND 10.1 AS complete, # Only filters out slower tests Using elapsedTime from tcpinfo snapshot
+  IF(NDTVersion LIKE "%canary%", (siteCount > 3 OR metroCount > 9), (siteCount > 6 OR metroCount > 18)) AS isHot,
+FROM tests
+WHERE isDownload
+  AND (machineSample = 1 # only allow one sample per day per client/machine.
+    OR (machineSample = 2 AND client.WScale = 0x78)) # Allow two samples per machine from 0x78 clients.
 ),
 
----------------------------------------------------------------------------
-# Count tests per machine, and join with hours per machine
-machine_summary AS (
-  SELECT
-    tests_per_client.* EXCEPT(TestTime, uuid),
-    --test_date, metro, site, machine, client,
-    COUNT(DISTINCT uuid) AS tests,
-    machine_hours.* EXCEPT(metro, site, machine, test_date, tests)
-  FROM tests_per_client LEFT JOIN hours_per_day_per_machine machine_hours
-  ON (tests_per_client.metro = machine_hours.metro AND
-      tests_per_client.site = machine_hours.site AND
-      tests_per_client.machine = machine_hours.machine AND
-      tests_per_client.test_date = machine_hours.test_date)
-  GROUP BY metro, site, machine, client, test_date, hours
-),
-
----------------------------------------------------------------------------
-# This will be very expensive.
-# This should create a lot of empty rows, for clients that appear in metro, but not on a machine.
-with_hours AS (
-  SELECT machine_summary.*, good_machines_per_metro.* EXCEPT(test_date, metro, machines)
-  FROM good_machines_per_metro LEFT JOIN machine_summary
-  ON (machine_summary.metro = good_machines_per_metro.metro AND
-    machine_summary.test_date = good_machines_per_metro.test_date)
-),
-
----------------------------------------------------------------------------
-# Not clear if this is actually useful as aggregate.
-metro_summary AS (
-  SELECT
-    CURRENT_DATE() AS update_time, test_date, metro, client,
-    ARRAY_AGG( STRUCT( site, machine, tests ) ORDER BY site, machine) AS machines,
-    metro_machines, metro_hours, good_machines, good_hours,
-  FROM with_hours
-  GROUP BY metro, client, test_date, good_hours, metro_hours, good_machines, metro_machines
-),
-
----------------------------------------------------------------------------
-# All metros, 7 dates takes about 1 slot hour, produces 2M rows of good clients.
-# CROSS JOIN produces about 150M rows.
-
-# flatten the per metro data, so that we have a row for each machine/client/date
-metro_machine_summary AS (
-  SELECT test_date, metro, client, CONCAT(site, ".", machine) AS machine, tests
-  FROM metro_summary JOIN UNNEST(metro_summary.machines)
-  GROUP BY test_date, metro, client, site, machine, tests
-),
-
----------------------------------------------------------------------------
-# extract complete list of machine per metro/date
-machine_hours AS (
-  SELECT test_date, metro, machine
-  FROM metro_machine_summary
-  GROUP BY test_date, metro, machine
-),
-
----------------------------------------------------------------------------
-# extract complete list of clients per metro/date
-clients AS (
-  SELECT test_date, metro, client
-  FROM metro_machine_summary
-  WHERE client != ""
-  GROUP BY test_date, metro, client
-),
-
----------------------------------------------------------------------------
-# create a complete list of machine/client pairs per metro/date
-# This is quite large - about 100M pairs worldwide for a one week window.
-machine_clients AS (
-  SELECT machine_hours.test_date,
-    machine_hours.metro,
-    machine_hours.machine,
-    clients.client
-  FROM machine_hours CROSS JOIN clients
-  WHERE machine_hours.metro = clients.metro AND machine_hours.test_date = clients.test_date
-),
-
----------------------------------------------------------------------------
-# Now join the machine/client pairs with the original metro_machine_summaryed data.
-# This produces a full complement of rows for each client/metro/date.
-joined AS (
-  SELECT machine_clients.test_date,
-  machine_clients.metro,
-  machine_clients.machine,
-  machine_clients.client,
-  IF(metro_machine_summary.tests IS NULL, 0, metro_machine_summary.tests) AS tests
-  FROM machine_clients LEFT JOIN metro_machine_summary ON
-    machine_clients.test_date = metro_machine_summary.test_date AND
-    machine_clients.metro = metro_machine_summary.metro AND
-    machine_clients.client = metro_machine_summary.client AND
-    machine_clients.machine = metro_machine_summary.machine
-),
-
----------------------------------------------------------------------------
-# Now aggregate over the past week, to produce machine_summary complete distribution of tests
-# per client across all machine_hours in each metro.
-past_week AS (
-  SELECT
-    test_date AS date, metro, machine, client,
-    SUM(tests) OVER weekly_window AS weekly_tests,
-    MIN(test_date) OVER weekly_window AS min_date,
-  FROM joined
-  GROUP BY date, metro, client, machine, tests
-  WINDOW weekly_window AS (
-    PARTITION BY client, machine
-    ORDER BY UNIX_DATE(test_date) RANGE BETWEEN 6 PRECEDING AND CURRENT ROW
-  )
-),
-
----------------------------------------------------------------------------
-# Now summarize the data for each client/metro
-weekly_summary AS (
-  SELECT
-    date, metro, client,
-    COUNTIF(weekly_tests > 0) AS test_machines,
-    COUNT(machine) AS machines,
-    SUM(weekly_tests) total_tests,
-    MIN(min_date) AS min_date,
-    # These count the number of machines with 0,1,2,3 or more tests
-    # These are useful to determining whether the client is statistically well behaved
-    MIN(weekly_tests) AS min,
-    MAX(weekly_tests) AS max,
-    COUNTIF(weekly_tests = 0) AS zeros,
-    COUNTIF(weekly_tests = 1) AS ones,
-    COUNTIF(weekly_tests = 2) AS twos,
-    COUNTIF(weekly_tests = 3) AS threes,
-    COUNTIF(weekly_tests > 3) AS more,
-  FROM past_week
-  GROUP BY date, metro, client
-),
-
----------------------------------------------------------------------------
-# Metro stats
-# Order:
-#  2020-06-06 ndt5 per machine client stats, last 10 days
-#  2020-06-07 Client stats
-#  2020-06-16 Metro stats
-
-# Ideally, this should be based on binomial distribution likelihood.
-# However, for now Im using machine_summary simpler criteria that is sub-optimal.
-# This could also be machine_summary sliding window partition if we want to compute multiple dates.
-good_clients AS (
-  SELECT * FROM weekly_summary # mlab-sandbox.gfr.client_weekly_stats
-  --WHERE date BETWEEN DATE_SUB(DATE(@startdate), INTERVAL 8 DAY) AND DATE(@enddate)
-  WHERE client NOT IN
-          ("45.56.98.222", "35.192.37.249", "35.225.75.192", "23.228.128.99",
-          "2600:3c03::f03c:91ff:fe33:819",  "2605:a601:f1ff:fffe::99")
-  # Exclude clients more than twice as many tests as machines in the metro
-  --AND total_tests < 2*machines
-  # Good clients will have similar counts across all machines
-  AND max <= min + SQRT(machines)  -- up to 3 machines -> max = 1, 4 machines -> max = 2, ALL 15 machines -> spread < 4
-  # If there are fewer tests than machines, we expect lots of singletons
-  --AND (total_tests > machines OR ones >= twos)
-  ORDER BY machines DESC, metro
-),
-
----------------------------------------------------------------------------
-downloads AS (
-  SELECT
-    test_date, TestTime, metro, site, machine, Client, Server,
-    clientName, clientIP, uuid,
-    REGEXP_EXTRACT(uuid, "(ndt-?.*)-.*") AS NDTVersion,
-    CongestionControl AS cc,  #TODO
-    MeanThroughputMbps AS mbps,
-    #raw.Download[x].TCPInfo.Retransmits,  # empty/NULL
-    MinRTT,       # empty/NULL
-    duration,
-    MeanThroughputMbps <= 0.1 AS slow,
-    duration BETWEEN 9 AND 13 AS complete,
-  FROM add_client_name
-),
-
----------------------------------------------------------------------------
-# Good downloads should include only those clients that meet the good_client criteria.
-good_downloads AS (
-  SELECT D.*
-  FROM downloads D JOIN good_clients G ON D.clientIP = G.client AND D.metro = G.metro AND D.test_date = G.date
-),
+--------------------------------------------------------------
 
 stats AS (
-  SELECT test_date, CURRENT_DATE() AS compute_date, 
-    Client.Geo.countryName,
-    Client.Network.ASName,
-    metro, site, machine, 
-    clientName, NDTVersion, complete, slow, COUNT(DISTINCT clientIP) AS clients, count(uuid) AS tests, 
-    ROUND(EXP(AVG(IF(mbps > 0, LN(mbps), NULL))),2) AS log_mean_speed, 
-    # ndt7 has only TCPINFO MinRTT, and reports in microseconds??  Using MinRTT instead of appMinRTT here and below
-    # ndt5 was reporting in nanoseconds??
-    ROUND(SAFE_DIVIDE(COUNTIF(MinRTT < 10), COUNT(uuid)),3) AS rttUnder10msec,
-    ROUND(APPROX_QUANTILES(MinRTT, 101)[OFFSET(50)],3) AS medianMinRTT,
-    ROUND(AVG(IF(MinRTT<10000,MinRTT,NULL)),3) AS meanMinRTT, # Ignore insane values over 10 seconds
-    ROUND(EXP(AVG(IF(MinRTT > 0, LN(MinRTT), 0))),3) AS logMeanMinRTT,
-    # AVG(Retransmits) AS avgRetransmits,
-    # Pearson correlation between ln(minRTT) and ln(bandwidth).  Ln produces much higher correlation (.5 vs .3)
-    # suggesting that the long tail of high speed / low RTT undermines the correlation without the LOG.
-    ROUND(CORR(IF(MinRTT > 0, LN(1/MinRTT), NULL) , IF(mbps > 0, LN(mbps), NULL)), 3) AS pearson,
-    --ROUND(AVG(SAFE_DIVIDE(SumRTT,CountRTT))/1000000,2) AS meanAppAvgRTT,
-    ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(10)],2) AS q10,
-    ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(25)],2) AS q25,
-    ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(50)],2) AS q50,
-    ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(75)],2) AS q75,
-    ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(90)],2) AS q90,
-    ROUND(MAX(mbps),2) AS max,
-    ROUND(SAFE_DIVIDE(COUNTIF(mbps < 1), COUNT(uuid)),3) AS under_1,
-    ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 1 AND 3), COUNT(uuid)),3) AS _1_3,
-    ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 3 AND 10), COUNT(uuid)),3) AS _3_10,
-    ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 10 AND 30), COUNT(uuid)),3) AS _10_30,
-    ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 30 AND 100), COUNT(uuid)),3) AS _30_100,
-    ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 100 AND 300), COUNT(uuid)),3) AS _100_300,
-    ROUND(SAFE_DIVIDE(COUNTIF(mbps > 300), COUNT(uuid)),3) AS over_300,
-    COUNTIF(MinRTT > 50) AS far,
-    ROUND(EXP(AVG(IF(MinRTT > 50 AND mbps > 0, LN(mbps), NULL))),3) AS logMeanFarMbps,
-  FROM good_downloads
-  GROUP BY test_date, countryName, ASName, metro, site, machine, NDTVersion, clientName, complete, slow
+SELECT test_date, CURRENT_DATE() AS compute_date, 
+Client.Geo.countryName,
+Client.Network.ASName,
+metro, site, machine, 
+client.Name AS clientName,
+client.OS AS clientOS,
+isHot AS clientIsHot,
+FORMAT("%02X", client.WScale) AS clientWScale,
+NDTVersion, complete, slow, COUNT(DISTINCT ClientID) AS clients, count(uuid) AS tests, 
+ROUND(EXP(AVG(IF(mbps > 0, LN(mbps), NULL))),2) AS log_mean_speed, 
+# ndt7 has only TCPINFO MinRTT, and reports in microseconds??  Using MinRTT instead of appMinRTT here and below
+# ndt5 was reporting in nanoseconds??
+ROUND(SAFE_DIVIDE(COUNTIF(MinRTT < 10), COUNT(uuid)),3) AS rttUnder10msec,
+ROUND(APPROX_QUANTILES(MinRTT, 101)[OFFSET(50)],3) AS medianMinRTT,
+ROUND(AVG(IF(MinRTT<10000,MinRTT,NULL)),3) AS meanMinRTT, # Ignore insane values over 10 seconds
+ROUND(EXP(AVG(IF(MinRTT > 0, LN(MinRTT), 0))),3) AS logMeanMinRTT,
+AVG(LossRate) AS AvgLossRate,
+# AVG(Retransmits) AS avgRetransmits,
+# Pearson correlation between ln(minRTT) and ln(bandwidth).  Ln produces much higher correlation (.5 vs .3)
+# suggesting that the long tail of high speed / low RTT undermines the correlation without the LOG.
+ROUND(CORR(IF(MinRTT > 0, LN(1/MinRTT), NULL) , IF(mbps > 0, LN(mbps), NULL)), 3) AS pearson,
+--ROUND(AVG(SAFE_DIVIDE(SumRTT,CountRTT))/1000000,2) AS meanAppAvgRTT,
+ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(10)],2) AS q10,
+ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(25)],2) AS q25,
+ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(50)],2) AS q50,
+ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(75)],2) AS q75,
+ROUND(APPROX_QUANTILES(mbps, 101)[OFFSET(90)],2) AS q90,
+ROUND(MAX(mbps),2) AS max,
+ROUND(SAFE_DIVIDE(COUNTIF(mbps < 1), COUNT(uuid)),3) AS under_1,
+ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 1 AND 3), COUNT(uuid)),3) AS _1_3,
+ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 3 AND 10), COUNT(uuid)),3) AS _3_10,
+ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 10 AND 30), COUNT(uuid)),3) AS _10_30,
+ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 30 AND 100), COUNT(uuid)),3) AS _30_100,
+ROUND(SAFE_DIVIDE(COUNTIF(mbps BETWEEN 100 AND 300), COUNT(uuid)),3) AS _100_300,
+ROUND(SAFE_DIVIDE(COUNTIF(mbps > 300), COUNT(uuid)),3) AS over_300,
+COUNTIF(MinRTT > 50) AS far,
+ROUND(EXP(AVG(IF(MinRTT > 50 AND mbps > 0, LN(mbps), NULL))),3) AS logMeanFarMbps,
+FROM subset
+GROUP BY test_date, countryName, ASName, metro, site, machine, NDTVersion, 
+client.Name, client.OS, client.WScale, isHot,
+complete, slow
 )
 
 SELECT * FROM stats WHERE test_date BETWEEN @startdate AND @enddate
---ORDER BY clientName, site, metro, ASName, countryName, complete DESC, slow

--- a/statistics/queries/canary.sql
+++ b/statistics/queries/canary.sql
@@ -135,8 +135,8 @@ client.Name AS clientName,
 client.OS AS clientOS,
 isHot AS clientIsHot,
 FORMAT("%02X", client.WScale) AS clientWScale,
-# TODO - replace clients with endpoints, here and in grafana queries.
-NDTVersion, complete, slow, COUNT(DISTINCT endpointHash) AS clients, count(uuid) AS tests, 
+# TODO - replace clients with endpoints in grafana queries, then delete clients column.
+NDTVersion, complete, slow, COUNT(DISTINCT endpointHash) AS clients, COUNT(DISTINCT endpointHash) AS endpoints, count(uuid) AS tests, 
 ROUND(EXP(AVG(IF(mbps > 0, LN(mbps), NULL))),2) AS log_mean_speed, 
 # ndt7 has only TCPINFO MinRTT, and reports in microseconds??  Using MinRTT instead of appMinRTT here and below
 # ndt5 was reporting in nanoseconds??


### PR DESCRIPTION
This greatly simplifies the client/test filter.  It uses a similar strategy to the one that we are moving toward for general debiasing and client clustering, which will eventually be implemented in public views in measurement-lab and in mlab-collaboration projects.

There are fairly good comments in the SQL to explain most of what is going on.

We expect that in a month or so, the general purpose view will be made public, at which time this query can be modified to use that view, instead of duplicating a lot of the SQL code.

The code has been tested by running a bq query manually to generate gfr_stats_z and gfr_stats_tmp tables.  These in turn can be used in the prototype canary dashboards.

https://grafana.mlab-sandbox.measurementlab.net/d/h6850_v7z/gfr-canary-vs-prod-support-both-canary-configs has been updated to incorporate the clientIsHot field, which can be used to clarify the subtle differences in some hot clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/78)
<!-- Reviewable:end -->
