### PR TITLE
Change Formatter.Where to .Partition w/ exporter query updates

### DIFF
--- a/annotation/exports/tcpinfo_annotation_export.sql
+++ b/annotation/exports/tcpinfo_annotation_export.sql
@@ -27,7 +27,7 @@ WITH annotations AS (
     FROM `mlab-oti.base_tables.tcpinfo`
     WHERE DATE(TestTime) = DATE('{{ .partitionID }}')
       AND DATE('{{ .partitionID }}') BETWEEN
-	      DATE_SUB(DATE(_PARTITIONTIME), INTERVAL 1 DAY)
+          DATE_SUB(DATE(_PARTITIONTIME), INTERVAL 1 DAY)
       AND DATE_ADD(DATE(_PARTITIONTIME), INTERVAL 1 DAY)
 )
 

--- a/annotation/exports/tcpinfo_annotation_export.sql
+++ b/annotation/exports/tcpinfo_annotation_export.sql
@@ -33,23 +33,23 @@ WITH annotations AS (
 
 SELECT
     tcpinfo.UUID,
-    MIN(tcpinfo.TestTime) as Timestamp,
-    ANY_VALUE(tcpinfo.ServerX) as Server,
-    ANY_VALUE(tcpinfo.ClientX) as Client,
-    REPLACE(CAST(DATE(tcpinfo.TestTime) AS STRING), "-", "/") as year_month_day,
+    MIN(tcpinfo.TestTime) AS Timestamp,
+    ANY_VALUE(tcpinfo.ServerX) AS Server,
+    ANY_VALUE(tcpinfo.ClientX) AS Client,
+    REPLACE(CAST(DATE(tcpinfo.TestTime) AS STRING), "-", "/") AS year_month_day,
 FROM
     tcpinfos AS tcpinfo
 LEFT OUTER JOIN
-    annotations as annotation
+    annotations AS annotation
 ON
         tcpinfo.UUID = annotation.id
     AND DATE(tcpinfo.TestTime) = annotation.date
 WHERE
         annotation.id IS NULL
     AND tcpinfo.UUID != ""
-    AND tcpinfo.UUID is not NULL
+    AND tcpinfo.UUID IS NOT NULL
     AND tcpinfo.ServerX.Site != ""
-    AND tcpinfo.ServerX.Geo is not NULL
+    AND tcpinfo.ServerX.Geo IS NOT NULL
 GROUP BY
     UUID,
     year_month_day

--- a/formatter/annotation.go
+++ b/formatter/annotation.go
@@ -40,20 +40,16 @@ func (f *AnnotationQueryFormatter) Partitions(source string) string {
 
 // Where returns a bigquery "WHERE" clause based on a row returned by running
 // the Partitions() query. The Annotation formatter conditions searches on the Date.
-func (f *AnnotationQueryFormatter) Where(row map[string]bigquery.Value) string {
+func (f *AnnotationQueryFormatter) Partition(row map[string]bigquery.Value) string {
 	date, ok := row["date"]
 	if !ok {
-		return "WHERE TRUE" // a noop expression.
+		return "0001-01-01" // a noop expression.
 	}
 	partition, ok := date.(civil.Date)
 	if !ok {
-		return "WHERE TRUE" // a noop expression.
+		return "0001-01-01" // a noop expression.
 	}
-	ds := fmt.Sprintf("%d-%02d-%02d", partition.Year, int(partition.Month), partition.Day)
-	template := `WHERE %s = DATE('%s') AND DATE('%s') BETWEEN
-            DATE_SUB(DATE(_PARTITIONTIME), INTERVAL 1 DAY)
-        AND DATE_ADD(DATE(_PARTITIONTIME), INTERVAL 1 DAY)`
-	return fmt.Sprintf(template, f.DateExpr, ds, ds)
+	return fmt.Sprintf("%d-%02d-%02d", partition.Year, int(partition.Month), partition.Day)
 
 }
 

--- a/formatter/annotation.go
+++ b/formatter/annotation.go
@@ -38,8 +38,9 @@ func (f *AnnotationQueryFormatter) Partitions(source string) string {
          ORDER BY date`, f.DateExpr, source, f.DateExpr)
 }
 
-// Where returns a bigquery "WHERE" clause based on a row returned by running
-// the Partitions() query. The Annotation formatter conditions searches on the Date.
+// Partition returns a date partition id based on a row returned by running the
+// Partitions() query. The partition id can be used in query templates.  The
+// Annotation formatter conditions searches on the Date.
 func (f *AnnotationQueryFormatter) Partition(row map[string]bigquery.Value) string {
 	date, ok := row["date"]
 	if !ok {

--- a/formatter/annotation_test.go
+++ b/formatter/annotation_test.go
@@ -67,7 +67,7 @@ func TestAnnotationQueryFormatter_Partitions(t *testing.T) {
 	}
 }
 
-func TestAnnotationQueryFormatter_Where(t *testing.T) {
+func TestAnnotationQueryFormatter_Partition(t *testing.T) {
 	tests := []struct {
 		name string
 		row  map[string]bigquery.Value
@@ -78,30 +78,28 @@ func TestAnnotationQueryFormatter_Where(t *testing.T) {
 			row: map[string]bigquery.Value{
 				"date": civil.DateOf(time.Date(2020, time.June, 01, 0, 0, 0, 0, time.UTC)),
 			},
-			want: `WHERE DATE(TestTime) = DATE('2020-06-01') AND DATE('2020-06-01') BETWEEN
-            DATE_SUB(DATE(_PARTITIONTIME), INTERVAL 1 DAY)
-        AND DATE_ADD(DATE(_PARTITIONTIME), INTERVAL 1 DAY)`,
+			want: `2020-06-01`,
 		},
 		{
 			name: "error-missing-date",
 			row: map[string]bigquery.Value{
 				"missing_date": 10,
 			},
-			want: "WHERE TRUE",
+			want: "0001-01-01",
 		},
 		{
 			name: "error-date-wrong-type",
 			row: map[string]bigquery.Value{
 				"date": time.Date(2020, time.June, 01, 0, 0, 0, 0, time.UTC),
 			},
-			want: "WHERE TRUE",
+			want: "0001-01-01",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := NewTCPINFOAnnotationQueryFormatter()
-			if got := f.Where(tt.row); got != tt.want {
-				t.Errorf("AnnotationQueryFormatter.Where() = %v, want %v", got, tt.want)
+			if got := f.Partition(tt.row); got != tt.want {
+				t.Errorf("AnnotationQueryFormatter.Partition() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/formatter/stats.go
+++ b/formatter/stats.go
@@ -33,11 +33,11 @@ func (f *StatsQueryFormatter) Partitions(source string) string {
 		ORDER BY COUNT(*) DESC`, source)
 }
 
-// Where returns a bigquery "WHERE" clause based on a row returned by running
-// the Partitions() query.
-func (f *StatsQueryFormatter) Where(row map[string]bigquery.Value) string {
+// Partition returns a shard partition id based on a row returned by running the
+// Partitions() query. The partition id can be used in query templates.
+func (f *StatsQueryFormatter) Partition(row map[string]bigquery.Value) string {
 	partition := row["shard"].(int64)
-	return fmt.Sprintf("WHERE shard = %d", partition)
+	return fmt.Sprintf("%d", partition)
 }
 
 // Marshal converts an export query row into a byte result suitable for writing

--- a/formatter/stats.go
+++ b/formatter/stats.go
@@ -36,7 +36,14 @@ func (f *StatsQueryFormatter) Partitions(source string) string {
 // Partition returns a shard partition id based on a row returned by running the
 // Partitions() query. The partition id can be used in query templates.
 func (f *StatsQueryFormatter) Partition(row map[string]bigquery.Value) string {
-	partition := row["shard"].(int64)
+	shard, ok := row["shard"]
+	if !ok {
+		return "-1" // a noop expression.
+	}
+	partition, ok := shard.(int64)
+	if !ok {
+		return "-1" // a noop expression.
+	}
 	return fmt.Sprintf("%d", partition)
 }
 

--- a/formatter/stats_test.go
+++ b/formatter/stats_test.go
@@ -76,6 +76,20 @@ func TestStatsQueryFormatter_Partition(t *testing.T) {
 			},
 			want: "1234",
 		},
+		{
+			name: "error-missing-date",
+			row: map[string]bigquery.Value{
+				"missing_shard": 10,
+			},
+			want: "-1",
+		},
+		{
+			name: "error-date-wrong-type",
+			row: map[string]bigquery.Value{
+				"shard": float64(1.3),
+			},
+			want: "-1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/formatter/stats_test.go
+++ b/formatter/stats_test.go
@@ -63,7 +63,7 @@ func TestStatsQueryFormatter_Partitions(t *testing.T) {
 	}
 }
 
-func TestStatsQueryFormatter_Where(t *testing.T) {
+func TestStatsQueryFormatter_Partition(t *testing.T) {
 	tests := []struct {
 		name string
 		row  map[string]bigquery.Value
@@ -74,14 +74,14 @@ func TestStatsQueryFormatter_Where(t *testing.T) {
 			row: map[string]bigquery.Value{
 				"shard": int64(1234),
 			},
-			want: "WHERE shard = 1234",
+			want: "1234",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := NewStatsQueryFormatter()
-			if got := f.Where(tt.row); got != tt.want {
-				t.Errorf("StatsQueryFormatter.Where() = %v, want %v", got, tt.want)
+			if got := f.Partition(tt.row); got != tt.want {
+				t.Errorf("StatsQueryFormatter.Partition() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/statistics/exports/cities.sql
+++ b/statistics/exports/cities.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY continent_code, country_code, ISO3166_2region1, city, date, bucket_min

--- a/statistics/exports/cities_asn.sql
+++ b/statistics/exports/cities_asn.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY continent_code, country_code, ISO3166_2region1, city, asn, date, bucket_min

--- a/statistics/exports/continents.sql
+++ b/statistics/exports/continents.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY continent_code, date

--- a/statistics/exports/continents_asn.sql
+++ b/statistics/exports/continents_asn.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY continent_code, asn, date, bucket_min

--- a/statistics/exports/countries.sql
+++ b/statistics/exports/countries.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY continent_code, country_code, date, bucket_min

--- a/statistics/exports/countries_asn.sql
+++ b/statistics/exports/countries_asn.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY continent_code, country_code, asn, date, bucket_min

--- a/statistics/exports/global_asn.sql
+++ b/statistics/exports/global_asn.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY asn, date, bucket_min

--- a/statistics/exports/regions.sql
+++ b/statistics/exports/regions.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY continent_code, country_code, ISO3166_2region1, date, bucket_min

--- a/statistics/exports/regions_asn.sql
+++ b/statistics/exports/regions_asn.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY continent_code, country_code, ISO3166_2region1, asn, date, bucket_min

--- a/statistics/exports/us_counties.sql
+++ b/statistics/exports/us_counties.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY GEOID, date, bucket_min

--- a/statistics/exports/us_counties_asn.sql
+++ b/statistics/exports/us_counties_asn.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY GEOID, asn, date, bucket_min

--- a/statistics/exports/us_states.sql
+++ b/statistics/exports/us_states.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY GEOID, date, bucket_min

--- a/statistics/exports/us_states_asn.sql
+++ b/statistics/exports/us_states_asn.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY GEOID, asn, date, bucket_min

--- a/statistics/exports/us_tracts.sql
+++ b/statistics/exports/us_tracts.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY GEOID, date, bucket_min

--- a/statistics/exports/us_tracts_asn.sql
+++ b/statistics/exports/us_tracts_asn.sql
@@ -1,4 +1,4 @@
 SELECT *, EXTRACT(YEAR from date) as year
 FROM {{ .sourceTable }}
-{{ .whereClause }}
+WHERE shard = {{ .partitionID }}
 ORDER BY GEOID, asn, date, bucket_min


### PR DESCRIPTION
This PR changes the Formatter interface by replacing `Where` (which returned a complete SQL WHERE clause) with `Partition` (which now returns only a partition identifier, that the SQL template can use as needed).

This change is in service of optimizing the query in `annotation/exports/tcpinfo_annotation_export.sql` to date-limit ranges in both the annotation and tcpinfo tables. With this change, typical dates only need to scan ~30-40GB (vs 400GB without date filters).

The consequence of this change is that the partition id (e.g. "shard" for statistics exports, and "date" for annotation exports) is a single parameter to the export query template. Before the `Where` method was returning an SQL clause, which makes reasoning about and optimizing the SQL export query more difficult or impossible. With this change, more of the actual SQL is present in the export query.

This change updates all uses of the `{{ .whereClause }}` in the `annotation/exports` and `statistics/exports` queries. Because only the partition ID is passed to the query template, the histograms and exports queries must agree on the partition column name, e.g. "shard".

FYI: @robertodauria

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/79)
<!-- Reviewable:end -->
