### PR TITLE
Add k8s configuration for annotation-export

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,7 @@ steps:
     - -c
     - |
       kubectl create configmap stats-pipeline-config \
-      --from-file=k8s/data-processing/config/config.json -o yaml --dry-run > \
+      --from-file=k8s/data-processing/config -o yaml --dry-run > \
       configmap-manifest.json
 
 - name: "gcr.io/cloud-builders/kubectl"
@@ -55,6 +55,39 @@ steps:
     - apply
     - -f
     - k8s/data-processing/services/stats-pipeline.yaml
+  env:
+  - CLOUDSDK_COMPUTE_REGION=$_COMPUTE_REGION
+  - CLOUDSDK_CONTAINER_CLUSTER=$_CLUSTER
+
+- name: "gcr.io/cloud-builders/gcloud"
+  id: "Generate manifest for annotation-export deployment"
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    sed 's/{{GCLOUD_PROJECT}}/${PROJECT_ID}/g' \
+    k8s/data-processing/deployments/annotation-export-template.yaml > \
+    annotation-export-manifest.yaml
+
+# Annotation export deployment and service.
+- name: "gcr.io/cloud-builders/gke-deploy"
+  id: "Create annotation-export deployment"
+  args:
+  - run
+  - --filename=k8s/data-processing/deployments/annotation-export-manifest.yaml
+  - --image=gcr.io/$PROJECT_ID/stats-pipeline:$_DOCKER_TAG
+  - --location=$_COMPUTE_REGION
+  - --cluster=$_CLUSTER
+  # gke-deploy will fail if the output folder is non-empty, thus we use
+  # different folders for the two executions of this tool.
+  - --output=annotation-export/
+
+- name: "gcr.io/cloud-builders/kubectl"
+  id: "Create annotation-export service"
+  args:
+    - apply
+    - -f
+    - k8s/data-processing/services/annotation-export.yaml
   env:
   - CLOUDSDK_COMPUTE_REGION=$_COMPUTE_REGION
   - CLOUDSDK_CONTAINER_CLUSTER=$_CLUSTER

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -74,7 +74,7 @@ steps:
   id: "Create annotation-export deployment"
   args:
   - run
-  - --filename=k8s/data-processing/deployments/annotation-export-manifest.yaml
+  - --filename=annotation-export-manifest.yaml
   - --image=gcr.io/$PROJECT_ID/stats-pipeline:$_DOCKER_TAG
   - --location=$_COMPUTE_REGION
   - --cluster=$_CLUSTER

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -24,7 +24,7 @@ spec:
           # stats-pipeline will write results to subdirectories of the named
           # -bucket directory.
           - -prometheusx.listen-address=:9990
-          - -exporter.query-workers=5
+          - -exporter.query-workers=4
           - -config=/etc/annotation-export/config-annotation-export.json
           - -export=annotation
           - -output=local

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -24,7 +24,7 @@ spec:
           # stats-pipeline will write results to subdirectories of the named
           # -bucket directory.
           - -prometheusx.listen-address=:9990
-          - -exporter.query-workers=8
+          - -exporter.query-workers=6
           - -config=/etc/annotation-export/config-annotation-export.json
           - -export=annotation
           - -output=local

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -24,7 +24,7 @@ spec:
           # stats-pipeline will write results to subdirectories of the named
           # -bucket directory.
           - -prometheusx.listen-address=:9990
-          - -exporter.query-workers=6
+          - -exporter.query-workers=5
           - -config=/etc/annotation-export/config-annotation-export.json
           - -export=annotation
           - -output=local
@@ -76,7 +76,7 @@ spec:
           - -metadata=MLAB.pusher.src.url=https://github.com/m-lab/pusher/tree/v1.20
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
         volumeMounts:
         - name: shared-export-dir
           mountPath: /var/spool/ndt

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -43,7 +43,7 @@ spec:
         # Note: This service runs on a dedicated 8-CPU node.
         resources:
           requests:
-            cpu: "6"
+            cpu: "5"
             memory: "2Gi"
         volumeMounts:
         - name: config-volume

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -24,7 +24,7 @@ spec:
           # stats-pipeline will write results to subdirectories of the named
           # -bucket directory.
           - -prometheusx.listen-address=:9990
-          - -exporter.query-workers=4
+          - -exporter.query-workers=8
           - -config=/etc/annotation-export/config-annotation-export.json
           - -export=annotation
           - -output=local

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -141,7 +141,9 @@ spec:
         configMap:
           name: stats-pipeline-config
       - name: shared-export-dir
-        emptyDir: {}
+        emptyDir:
+          # NOTE: allocates 50% of available RAM for tmpfs.
+          medium: Memory
       #- name: shared-ssd
       #  persistentVolumeClaim:
       #    claimName: auto-annotation-export-ssd0

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -1,0 +1,147 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: annotation-export
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: annotation-export
+  template:
+    metadata:
+      labels:
+        run: annotation-export
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      - name: stats-pipeline
+        # The exact image to be deployed is replaced by gke-deploy, this is
+        # a placeholder.
+        image: gcr.io/{{GCLOUD_PROJECT}}/stats-pipeline
+        args:
+          # NOTE: in "local" output mode, and export "annotation" mode, the
+          # stats-pipeline will write results to subdirectories of the named
+          # -bucket directory.
+          - -prometheusx.listen-address=:9990
+          - -exporter.query-workers=3
+          - -config=/etc/annotation-export/config-annotation-export.json
+          - -export=annotation
+          - -output=local
+          - -bucket=/var/spool/ndt/annotation
+          - -project={{GCLOUD_PROJECT}}
+        ports:
+          # This is so Prometheus can be scraped.
+          - name: prometheus-port
+            containerPort: 9990
+          - name: service-port
+            containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: prometheus-port
+        # Note: This service runs on a dedicated 8-CPU node.
+        resources:
+          requests:
+            cpu: "6"
+            memory: "2Gi"
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/annotation-export
+        #- name: shared-ssd
+        - name: shared-export-dir
+          mountPath: /var/spool/ndt
+      - name: pusher
+        image: measurementlab/pusher:v1.20
+        ports:
+          - name: pusher-port
+            containerPort: 9991
+        args:
+          - -prometheusx.listen-address=:9991
+          - -bucket=thirdparty-annotation-{{GCLOUD_PROJECT}}
+          - -experiment=ndt
+          - -datatype=annotation
+          - -directory=/var/spool/ndt
+          - -node_name=third-party
+          # The following thresholds create archive uploads more quickly than defaults.
+          # NOTE: JSON files compress around 60x, so 3MB archives are about 180MB on disk.
+          - -archive_size_threshold=2MB
+          - -max_file_age=10m               # After writing, No need to wait to upload a file (default 1h).
+          - -archive_wait_time_min=5m       # (default 30m0s)
+          - -archive_wait_time_expected=10m # (default 1h0m0s)
+          - -archive_wait_time_max=15m      # (default 2h0m0s)
+          - -sigterm_wait_time=60s
+          - -metadata=MLAB.server.name=data-processing
+          - -metadata=MLAB.experiment.name=ndt
+          - -metadata=MLAB.pusher.image=measurementlab/pusher:v1.20
+          - -metadata=MLAB.pusher.src.url=https://github.com/m-lab/pusher/tree/v1.20
+        resources:
+          requests:
+            cpu: "1"
+        volumeMounts:
+        #- name: shared-ssd
+        - name: shared-export-dir
+          mountPath: /var/spool/ndt
+
+      # Run a node-exporter as part of the pod so that it has access to the same
+      # namespace and volumes. This allows simple disk usage monitoring of the
+      # shared disk.
+      - image: prom/node-exporter:v0.18.1
+        name: node-exporter
+        # Note: only enable the filesystem collector, and ignore system paths.
+        args: ["--no-collector.arp",
+               "--no-collector.bcache",
+               "--no-collector.bonding",
+               "--no-collector.conntrack",
+               "--no-collector.cpu",
+               "--no-collector.cpufreq",
+               "--no-collector.diskstats",
+               "--no-collector.edac",
+               "--no-collector.entropy",
+               "--no-collector.filefd",
+               "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($|/)",
+               "--no-collector.hwmon",
+               "--no-collector.infiniband",
+               "--no-collector.ipvs",
+               "--no-collector.loadavg",
+               "--no-collector.mdadm",
+               "--no-collector.meminfo",
+               "--no-collector.netclass",
+               "--no-collector.netdev",
+               "--no-collector.netstat",
+               "--no-collector.nfs",
+               "--no-collector.nfsd",
+               "--no-collector.pressure",
+               "--no-collector.sockstat",
+               "--no-collector.stat",
+               "--no-collector.textfile",
+               "--no-collector.time",
+               "--no-collector.timex",
+               "--no-collector.uname",
+               "--no-collector.vmstat",
+               "--no-collector.xfs",
+               "--no-collector.zfs"]
+        ports:
+          - containerPort: 9100
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "500m"
+          limits:
+            memory: "10Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: shared-export-dir
+          mountPath: /var-spool-ndt
+          #name: shared-ssd
+      nodeSelector:
+        annotation-export-node: 'true'
+      volumes:
+      - name: config-volume
+        configMap:
+          name: stats-pipeline-config
+      - name: shared-export-dir
+        emptyDir: {}
+      #- name: shared-ssd
+      #  persistentVolumeClaim:
+      #    claimName: auto-annotation-export-ssd0

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -24,7 +24,7 @@ spec:
           # stats-pipeline will write results to subdirectories of the named
           # -bucket directory.
           - -prometheusx.listen-address=:9990
-          - -exporter.query-workers=3
+          - -exporter.query-workers=4
           - -config=/etc/annotation-export/config-annotation-export.json
           - -export=annotation
           - -output=local

--- a/k8s/data-processing/deployments/annotation-export-template.yaml
+++ b/k8s/data-processing/deployments/annotation-export-template.yaml
@@ -48,7 +48,6 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/annotation-export
-        #- name: shared-ssd
         - name: shared-export-dir
           mountPath: /var/spool/ndt
       - name: pusher
@@ -79,7 +78,6 @@ spec:
           requests:
             cpu: "1"
         volumeMounts:
-        #- name: shared-ssd
         - name: shared-export-dir
           mountPath: /var/spool/ndt
 
@@ -133,9 +131,8 @@ spec:
         volumeMounts:
         - name: shared-export-dir
           mountPath: /var-spool-ndt
-          #name: shared-ssd
       nodeSelector:
-        annotation-export-node: 'true'
+        stats-pipeline-node: 'true'
       volumes:
       - name: config-volume
         configMap:
@@ -144,6 +141,3 @@ spec:
         emptyDir:
           # NOTE: allocates 50% of available RAM for tmpfs.
           medium: Memory
-      #- name: shared-ssd
-      #  persistentVolumeClaim:
-      #    claimName: auto-annotation-export-ssd0

--- a/k8s/data-processing/services/annotation-export.yaml
+++ b/k8s/data-processing/services/annotation-export.yaml
@@ -1,0 +1,12 @@
+# A ClusterIP service to make stats-pipeline available to other pods.
+apiVersion: v1
+kind: Service
+metadata:
+  name: annotation-export-service
+spec:
+  type: ClusterIP
+  selector:
+    run: annotation-export
+  ports:
+    - protocol: TCP
+      port: 8080


### PR DESCRIPTION
This change adds the Kubernetes configuration for deploying the annotation-export to sandbox, staging, and production environments. The annotation-export configuration includes three containers: stats-pipeline (to produce annotation files), pusher (to archive and upload individual files), node-exporter (to monitor local disk utilization during export). This configuration uses an `emptyDir` mounted on tmpfs in RAM for faster performance. Because the stats-pipeline nodepool supports autoscaling, a new node will be created for this configuration.

A companion dashboard (not yet in version control) https://grafana.mlab-sandbox.measurementlab.net/d/XokjBPKnk/annotation-export-monitoring?orgId=1&from=now-12h&to=now allows tracking the progress of the annotation-export. The dashboard will be reviewed before running in production.

With this configuration, triggering the pipeline is still manual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/82)
<!-- Reviewable:end -->
