### PR TITLE
Fix races in export_test.go

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -174,7 +174,6 @@ func TestJSONExporter_marshalAndUpload(t *testing.T) {
 		if err != nil {
 			t.Errorf("marshalAndUpload() returned err: %v", err)
 		}
-		close(jobs)
 	}()
 	// Read from the channel. If the channel is closed and nothing has been
 	// sent, the function failed.
@@ -185,6 +184,7 @@ func TestJSONExporter_marshalAndUpload(t *testing.T) {
 	} else {
 		t.Errorf("marshalAndUpload() didn't send a value")
 	}
+	close(jobs)
 
 	// Call marshalAndUpload with a row that cannot be marshalled.
 	unmarshallableRow := bqRow{


### PR DESCRIPTION
This fixes two race conditions detected by go test -race.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/88)
<!-- Reviewable:end -->
