### PR TITLE
Use cron job for hopannotation1 export

### DIFF
--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -46,9 +46,7 @@ required but ignored.
 
 ## Kubernetes
 
-Only the hopannotation1 export process is available on Kubernetes.
-
-The export process is started via a CronJob which by default is scheduled to
+Only the hopannotation1 export process is available on Kubernetes. The export process is started via a CronJob which by default is scheduled to
 never run.
 
 To start an annotation export manually, run the following command on the

--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -46,6 +46,8 @@ required but ignored.
 
 ## Kubernetes
 
+Only the hopannotation1 export process is available on Kubernetes.
+
 The export process is started via a CronJob which by default is scheduled to
 never run.
 
@@ -53,5 +55,5 @@ To start an annotation export manually, run the following command on the
 `data-processing` cluster:
 
 ```sh
-kubectl create job --from=cronjob/annotation-export-cronjob annotation-export-manual
+kubectl create job --from=cronjob/hopannotation1-export-cronjob hopannotation1-export-manual
 ```

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -112,15 +112,15 @@ steps:
     stats-pipeline-cronjob.yaml
 
 - name: "gcr.io/cloud-builders/gcloud"
-  id: "Generate manifest for the annotation-export-cronjob"
+  id: "Generate manifest for the hopannotation1-export-cronjob"
   entrypoint: /bin/sh
   args:
   - -c
   - |
     sed -e 's/{{GCLOUD_PROJECT}}/${PROJECT_ID}/g' \
     -e "s/{{ANNOTATION_EXPORT_CRON_SCHEDULE}}/${_ANNOTATION_EXPORT_CRON_SCHEDULE}/g" \
-    k8s/data-processing/jobs/annotation-export-cronjob.template > \
-    annotation-export-cronjob.yaml
+    k8s/data-processing/jobs/hopannotation1-export-cronjob.template > \
+    hopannotation1-export-cronjob.yaml
 
 - name: "gcr.io/cloud-builders/gke-deploy"
   id: "Create stats-pipeline CronJob"
@@ -135,13 +135,13 @@ steps:
   - --output=stats-pipeline-runner/
 
 - name: "gcr.io/cloud-builders/gke-deploy"
-  id: "Create annotation-export CronJob"
+  id: "Create hopannotation1-export CronJob"
   args:
   - run
-  - --filename=annotation-export-cronjob.yaml
+  - --filename=hopannotation1-export-cronjob.yaml
   - --image=gcr.io/$PROJECT_ID/stats-pipeline-runner:$_DOCKER_TAG
   - --location=$_COMPUTE_REGION
   - --cluster=$_CLUSTER
   # gke-deploy will fail if the output folder is non-empty, thus we use
   # different folders for the two executions of this tool.
-  - --output=annotation-export-runner/
+  - --output=hopannotation1-export-runner/

--- a/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
+++ b/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
@@ -1,5 +1,5 @@
 # cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: v1
 kind: CronJob
 metadata:
   name: hopannotation1-export-cronjob

--- a/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
+++ b/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
@@ -1,5 +1,5 @@
 # cronjob.yaml
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: hopannotation1-export-cronjob

--- a/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
+++ b/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: annotation-export-cronjob
+  name: hopannotation1-export-cronjob
 spec:
   schedule: "{{ANNOTATION_EXPORT_CRON_SCHEDULE}}"
   concurrencyPolicy: Forbid
@@ -19,4 +19,4 @@ spec:
             args:
             - /bin/bash
             - run-pipeline.sh
-            - "annotation-export-service:8080"
+            - "hopannotation1-export-service:8080"

--- a/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
+++ b/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
@@ -1,5 +1,5 @@
 # cronjob.yaml
-apiVersion: v1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hopannotation1-export-cronjob


### PR DESCRIPTION
This PR re-purposes the annotation-export CronJob to be used for the hopannotation1-export.

The job can be monitored in sandbox with the dashboard https://grafana.mlab-sandbox.measurementlab.net/d/XokjBPKnj/annotation-export-monitoring?orgId=1&from=1640818320000&to=now&var-datasource=Data%20Processing%20(mlab-sandbox)&refresh=1m.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/93)
<!-- Reviewable:end -->
