### PR TITLE
Decrease workers for hopannotation1 export

### DIFF
--- a/k8s/data-processing/deployments/hopannotation1-export-template.yaml
+++ b/k8s/data-processing/deployments/hopannotation1-export-template.yaml
@@ -26,7 +26,7 @@ spec:
           # stats-pipeline will write results to subdirectories of the named
           # -bucket directory.
           - -prometheusx.listen-address=:9990
-          - -exporter.query-workers=2
+          - -exporter.query-workers=3
           - -config=/etc/hopannotation1-export/config-hopannotation1-export.json
           - -export=hopannotation1
           - -output=local

--- a/k8s/data-processing/deployments/hopannotation1-export-template.yaml
+++ b/k8s/data-processing/deployments/hopannotation1-export-template.yaml
@@ -26,7 +26,7 @@ spec:
           # stats-pipeline will write results to subdirectories of the named
           # -bucket directory.
           - -prometheusx.listen-address=:9990
-          - -exporter.query-workers=4
+          - -exporter.query-workers=6
           - -config=/etc/hopannotation1-export/config-hopannotation1-export.json
           - -export=hopannotation1
           - -output=local

--- a/k8s/data-processing/deployments/hopannotation1-export-template.yaml
+++ b/k8s/data-processing/deployments/hopannotation1-export-template.yaml
@@ -26,7 +26,7 @@ spec:
           # stats-pipeline will write results to subdirectories of the named
           # -bucket directory.
           - -prometheusx.listen-address=:9990
-          - -exporter.query-workers=6
+          - -exporter.query-workers=2
           - -config=/etc/hopannotation1-export/config-hopannotation1-export.json
           - -export=hopannotation1
           - -output=local


### PR DESCRIPTION
4 workers was causing the number of INODES to drop to zero.
With 3 workers, it doesn't drop below 3mil.

Before:
https://grafana.mlab-sandbox.measurementlab.net/d/XokjBPKnj/annotation-export-monitoring?orgId=1&from=1640195880000&to=1640210280000&var-datasource=Data+Processing+%28mlab-sandbox%29&viewPanel=46

After:
https://grafana.mlab-sandbox.measurementlab.net/d/XokjBPKnj/annotation-export-monitoring?orgId=1&from=1640213760000&to=now&var-datasource=Data+Processing+%28mlab-sandbox%29&viewPanel=46

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/96)
<!-- Reviewable:end -->
