### PR TITLE
Modify hopannotation1 formatter to include paris-traceroute data

### DIFF
--- a/formatter/hopannotation1.go
+++ b/formatter/hopannotation1.go
@@ -31,7 +31,7 @@ func (f *HopAnnotation1QueryFormatter) Partitions(source string) string {
 	return fmt.Sprintf(
 		`SELECT DATE(TestTime) as date
          FROM %s
-         WHERE DATE(TestTime) BETWEEN DATE('2019-03-29') AND DATE('2021-09-08')
+         WHERE DATE(TestTime) BETWEEN DATE('2013-05-08') AND DATE('2021-09-08')
          GROUP BY date
          ORDER BY date`, source)
 }

--- a/formatter/hopannotation1_test.go
+++ b/formatter/hopannotation1_test.go
@@ -52,7 +52,7 @@ func TestHopAnnotation1QueryFormatter_Partitions(t *testing.T) {
 			source: "a.b.c",
 			want: `SELECT DATE(TestTime) as date
          FROM a.b.c
-         WHERE DATE(TestTime) BETWEEN DATE('2019-03-29') AND DATE('2021-09-08')
+         WHERE DATE(TestTime) BETWEEN DATE('2013-05-08') AND DATE('2021-09-08')
          GROUP BY date
          ORDER BY date`,
 		},


### PR DESCRIPTION
Paris-traceroute annotations pushed to GCS:
https://pantheon.corp.google.com/storage/browser/archive-mlab-sandbox/ndt/hopannotation1?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=mlab-sandbox&prefix=&forceOnObjectsSortingFiltering=false

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/99)
<!-- Reviewable:end -->
