### PR TITLE
Use batch/v1 API

### DIFF
--- a/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
+++ b/k8s/data-processing/jobs/hopannotation1-export-cronjob.template
@@ -1,5 +1,5 @@
 # cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hopannotation1-export-cronjob

--- a/k8s/data-processing/jobs/stats-pipeline-cronjob.yaml.template
+++ b/k8s/data-processing/jobs/stats-pipeline-cronjob.yaml.template
@@ -1,5 +1,5 @@
 # cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: stats-pipeline-cronjob


### PR DESCRIPTION
This changes resources from the stats-pipeline using the `batch/v1beta` API to the `batch/v1` API instead.

Part of:
* https://github.com/m-lab/etl-gardener/issues/379

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/100)
<!-- Reviewable:end -->
