### PR TITLE
Updates nodeSelector for deployments

### DIFF
--- a/k8s/data-pipeline/deployments/hopannotation1-export-template.yaml
+++ b/k8s/data-pipeline/deployments/hopannotation1-export-template.yaml
@@ -134,7 +134,7 @@ spec:
         - name: shared-export-dir
           mountPath: /var-spool-ndt
       nodeSelector:
-        stats-pipeline-node: 'true'
+        statistics-node: 'true'
       volumes:
       - name: config-volume
         configMap:

--- a/k8s/data-pipeline/deployments/stats-pipeline.yaml.template
+++ b/k8s/data-pipeline/deployments/stats-pipeline.yaml.template
@@ -50,7 +50,7 @@ spec:
         - name: config-volume
           mountPath: /etc/stats-pipeline
       nodeSelector:
-        stats-pipeline-node: 'true'
+        statistics-node: 'true'
       volumes:
       - name: config-volume
         configMap:


### PR DESCRIPTION
All other data-pipeline workloads have simplified nodeSelectors and node labels of the form:

`<node pool name>-node="true"`

This one slipped by and this small commit resolves that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/stats-pipeline/118)
<!-- Reviewable:end -->
